### PR TITLE
Handle IPv4-mapped IPv6 addresses

### DIFF
--- a/nsupdate/context_processors.py
+++ b/nsupdate/context_processors.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 import time
 
 from .main.dnstools import put_ip_into_session
+from .main.iptools import normalize_ip
 
 from django.conf import settings
 
@@ -36,7 +37,7 @@ def update_ips(request):
     s = request.session
     t_now = int(time.time())
     # update and keep fresh using info from the request we have anyway:
-    ipaddr = request.META['REMOTE_ADDR']
+    ipaddr = normalize_ip(request.META['REMOTE_ADDR'])
     put_ip_into_session(s, ipaddr, max_age=MAX_IP_AGE / 2)
     # remove stale data to not show outdated IPs (e.g. after losing IPv6 connectivity):
     for key in ['ipv4', 'ipv6', ]:

--- a/nsupdate/main/iptools.py
+++ b/nsupdate/main/iptools.py
@@ -1,0 +1,17 @@
+"""
+Misc. IP tools: normalize, handle mapped addresses
+"""
+
+from netaddr import IPAddress
+
+def normalize_ip(ipaddr):
+    ipaddr = normalize_mapped_address(ipaddr)
+    return ipaddr
+
+def normalize_mapped_address(ipaddr):
+    ipaddr = IPAddress(ipaddr)
+
+    if ipaddr.is_ipv4_compat() or ipaddr.is_ipv4_mapped():
+        ipaddr = ipaddr.ipv4()
+
+    return str(ipaddr)

--- a/nsupdate/main/views.py
+++ b/nsupdate/main/views.py
@@ -19,6 +19,7 @@ from django.core.exceptions import PermissionDenied
 from django.utils.timezone import now
 
 from . import dnstools
+from .iptools import normalize_ip
 
 from .forms import (CreateHostForm, EditHostForm, CreateRelatedHostForm, EditRelatedHostForm,
                     CreateDomainForm, EditDomainForm, CreateUpdaterHostConfigForm, EditUpdaterHostConfigForm)
@@ -210,7 +211,7 @@ class AddHostView(CreateView):
     def form_valid(self, form):
         self.object = form.save(commit=False)
         try:
-            dnstools.add(self.object.get_fqdn(), self.request.META['REMOTE_ADDR'])
+            dnstools.add(self.object.get_fqdn(), normalize_ip(self.request.META['REMOTE_ADDR']))
         except dnstools.Timeout:
             success, level, msg = False, messages.ERROR, 'Timeout - communicating to name server failed.'
         except dnstools.NameServerNotAvailable:
@@ -265,7 +266,7 @@ class HostView(UpdateView):
     def get_context_data(self, *args, **kwargs):
         context = super(HostView, self).get_context_data(*args, **kwargs)
         context['nav_overview'] = True
-        context['remote_addr'] = self.request.META['REMOTE_ADDR']
+        context['remote_addr'] = normalize_ip(self.request.META['REMOTE_ADDR'])
         return context
 
 


### PR DESCRIPTION
Some reverse proxy configurations pass REMOTE_ADDR
as a IPv4-mapped IPv6 address when listening on a
IPv6 socket. This patch converts such a mapped
address into a IPv4 address at all usages of
REMOTE_ADDR. It handles both, the ::ffff:192.0.2.128
format as well as the deprecated ::192.0.2.128 format.
