### PR TITLE
Explain related hosts interface id usage

### DIFF
--- a/docs/user.rst
+++ b/docs/user.rst
@@ -185,6 +185,7 @@ You also see it prepends the related host's name to your mainhost's FQDN.
 For the related hosts's address, p is same prefix as above (the host is on same
 network), but r comes from what you entered as interface ID into the related
 host record.
+The interface ID must be a proper suffix notation. A proper suffix notation starts with `::`
 
 In other words:
 


### PR DESCRIPTION
We stumbled over why it didnt work. Using proper syntax helped. Should we file a bug report for the software itself to catch this?