### PR TITLE
[FIX] get real ip when behind reverse proxy

### DIFF
--- a/nsupdate/context_processors.py
+++ b/nsupdate/context_processors.py
@@ -37,7 +37,10 @@ def update_ips(request):
     s = request.session
     t_now = int(time.time())
     # update and keep fresh using info from the request we have anyway:
-    ipaddr = normalize_ip(request.META['REMOTE_ADDR'])
+    try:
+        ipaddr = normalize_ip(request.META['HTTP_X_FORWARDED_FOR'])
+    except KeyError:
+        ipaddr = normalize_ip(request.META['REMOTE_ADDR'])
     put_ip_into_session(s, ipaddr, max_age=MAX_IP_AGE / 2)
     # remove stale data to not show outdated IPs (e.g. after losing IPv6 connectivity):
     for key in ['ipv4', 'ipv6', ]:


### PR DESCRIPTION
When using a (nginx) reverse proxy in front of the (gunicorn) app server, only the local ip is passed to django.
This fix first tries to obtain the real remote ip via 'HTTP_X_FORWARDED_FOR' and only if it's unset it uses 'REMOTE_ADDR' as remote ip.

/etc/nginx/sites-available/my_django_project.conf:
    
    ...
        location / {
            proxy_set_header   Host $host;
            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_redirect off;
            proxy_pass http://app_server;
    }