### PR TITLE
Update pfSense tab to get IP from Result Match

### DIFF
--- a/nsupdate/main/templates/main/includes/tabbed_router_configuration.html
+++ b/nsupdate/main/templates/main/includes/tabbed_router_configuration.html
@@ -286,7 +286,7 @@ config service "ipv4ddns"
             <tr><td>Username</td><td>{{ host.get_fqdn|default:"&lt;your hostname&gt;" }}</td></tr>
             <tr><td>Password</td><td>{{ update_secret|default:"&lt;your secret&gt;" }}</td></tr>
             <tr><td>Update URL</td><td>https://{{ WWW_IPV4_HOST }}/nic/update</td></tr>
-            <tr><td>Result Match</td><td>good|nochg</td></tr>
+            <tr><td>Result Match</td><td>good %IP%|nochg %IP%</td></tr>
             <tr><td>Description</td><td>update DDNS host with IP v4 address</td></tr>
         </table>
     </div>


### PR DESCRIPTION
added %IP% for pfSense result match to properly catch the cached IP address. Without pfSense reports 0.0.0.0 in the webgui.