### PR TITLE
update badges, new readthedocs.io url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,8 @@ Documentation: https://nsupdateinfo.readthedocs.io/
 
 Software project: https://github.com/nsupdate-info/nsupdate.info
 
+|doc| |build| |coverage| |package|
+
 .. |doc| image:: https://readthedocs.org/projects/nsupdate/badge/?version=stable
         :alt: Documentation
         :target: https://nsupdateinfo.readthedocs.io/en/stable/


### PR DESCRIPTION
but: readthedocs.io does not work for the badge