### PR TITLE
Add missing closing div after dyndnsc sample configuration

### DIFF
--- a/nsupdate/main/templates/main/includes/tabbed_router_configuration.html
+++ b/nsupdate/main/templates/main/includes/tabbed_router_configuration.html
@@ -209,6 +209,7 @@ updater-password = {{ update_secret|default:"&lt;your secret&gt;" }}
 detector = webcheck6
 
 </pre>
+    </div>
     <div class="tab-pane" id="ipfire">
         <h4>IPFire 2.17 Core Update 90</h4>
         <p>Homepage: <a href="http://ipfire.org/">http://ipfire.org</a></p>


### PR DESCRIPTION
https://github.com/nsupdate-info/nsupdate.info/commit/c9bc5bffb04bd1bf1f1e71b064326fe3edb2454d was missing the closing `</div>` which breaks the `tab-pane`