### PR TITLE
Change requirements to accepted comparisons operator

### DIFF
--- a/requirements.d/all.txt
+++ b/requirements.d/all.txt
@@ -1,7 +1,7 @@
 # packages always needed
 dnspython
 netaddr
-django~=1.11.0
+django>=1.11.0
 django-bootstrap-form
 django-registration-redux
 django-extensions


### PR DESCRIPTION
Running pip install on requirements.d/all.txt (in this example invoked by prod.txt) yields following error, while using `pip 1.5.6  (python 3.4)`.

```
pip install -r requirements.d/prod.txt
Exception:
Traceback (most recent call last):
  File "/var/www/nsupdate.info/.venv/lib/python3.4/site-packages/pip/basecommand.py", line 122, in main
    status = self.run(options, args)
  File "/var/www/nsupdate.info/.venv/lib/python3.4/site-packages/pip/commands/install.py", line 274, in run
    for req in parse_requirements(filename, finder=finder, options=options, session=session):
  File "/var/www/nsupdate.info/.venv/lib/python3.4/site-packages/pip/req.py", line 1570, in parse_requirements
    for item in parse_requirements(req_url, finder, comes_from=filename, options=options, session=session):
  File "/var/www/nsupdate.info/.venv/lib/python3.4/site-packages/pip/req.py", line 1632, in parse_requirements
    req = InstallRequirement.from_line(line, comes_from, prereleases=getattr(options, "pre", None))
  File "/var/www/nsupdate.info/.venv/lib/python3.4/site-packages/pip/req.py", line 173, in from_line
    return cls(req, comes_from, url=url, prereleases=prereleases)
  File "/var/www/nsupdate.info/.venv/lib/python3.4/site-packages/pip/req.py", line 71, in __init__
    req = pkg_resources.Requirement.parse(req)
  File "/var/www/nsupdate.info/.venv/lib/python-wheels/setuptools-5.5.1-py2.py3-none-any.whl/pkg_resources.py", line 2793, in parse
    reqs = list(parse_requirements(s))
  File "/var/www/nsupdate.info/.venv/lib/python-wheels/setuptools-5.5.1-py2.py3-none-any.whl/pkg_resources.py", line 2721, in parse_requirements
    "version spec")
  File "/var/www/nsupdate.info/.venv/lib/python-wheels/setuptools-5.5.1-py2.py3-none-any.whl/pkg_resources.py", line 2686, in scan_list
    raise ValueError(msg, line, "at", line[p:])
ValueError: ('Expected version spec in', 'django~=1.11.0', 'at', '~=1.11.0')
```
Changing the operator `~=` to the accepted operator `>=` [0] fixes this problem.

[0] https://docs.python.org/3/distutils/setupscript.html#relationships-between-distributions-and-packages