### PR TITLE
add ugly workaround for crash in django-admin users --stale-check

### DIFF
--- a/nsupdate/management/commands/users.py
+++ b/nsupdate/management/commands/users.py
@@ -82,5 +82,8 @@ class Command(BaseCommand):
                     log_msg = check_staleness(u)
                 if log_msg:
                     log_msg = log_msg % dict(user=user)
-                    self.stdout.write(log_msg)
+                    try:
+                        self.stdout.write(log_msg)
+                    except UnicodeError:
+                        pass
             print_stats("after")


### PR DESCRIPTION
i tried repr(user), but somehow this did not help.
```
Traceback (most recent call last):
  File "/srv/nsupdate.info/env/bin/django-admin.py", line 5, in <module>
    management.execute_from_command_line()
  File "/srv/nsupdate.info/env/lib/python3.5/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/srv/nsupdate.info/env/lib/python3.5/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/nsupdate.info/env/lib/python3.5/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/nsupdate.info/env/lib/python3.5/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/srv/nsupdate.info/repo/nsupdate/management/commands/users.py", line 85, in handle
    self.stdout.write(log_msg)
  File "/srv/nsupdate.info/env/lib/python3.5/site-packages/django/core/management/base.py", line 110, in write
    self._out.write(force_str(style_func(msg)))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 1-2: ordinal not in range(128)
```