### PR TITLE
require dnspython < 1.17.0 for py27 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     platforms='any',
     setup_requires=['setuptools_scm'],
     install_requires=[
-        'dnspython',
+        'dnspython<1.17.0',  # 1.16 is last with py27 support
         'netaddr',
         'django',
         'django-bootstrap-form',


### PR DESCRIPTION
1.16.0 supports py27.
2.0.0 will be py3 only.

we expect that bugfix releases (if any) will be versioned 1.16.x
and won't break py27.

if there ever are other 1.x releases, it has to be checked whether
they are py27 compatible.