### PR TITLE
drop support for python 3.4, fixes #406

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ matrix:
     - python: "2.7"
       dist: trusty
       env: DJANGO=1.11 COVERAGE="coverage run -m" TEST_K="not ddns_client" TEST_OPTS="--pep8"
-    - python: "3.4"
-      dist: trusty
-      env: DJANGO=1.11
     - python: "3.5"
       dist: trusty
       env: DJANGO=1.11

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
you currently need either 2.7 or 3.5+.