### PR TITLE
use "load static", fixes #403

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     install_requires=[
         'dnspython<1.17.0',  # 1.16 is last with py27 support
         'netaddr',
-        'django',
+        'django>=1.11.0',
         'django-bootstrap-form',
         'django-registration-redux',
         'django-extensions',

--- a/src/nsupdate/templates/base.html
+++ b/src/nsupdate/templates/base.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 {% load i18n %}{% load bootstrap %}
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
django (since 1.10) supports this and internally will use staticfiles
if django.contrib.staticfiles is in INSTALLED_APPS (which is the case).

this should fix the deprecation warnings we got.

also: require django >= 1.11.0.