### PR TITLE
fix  Domain.generate_ns_secret()  storing bytes object into Domain.nameserver_update_secret

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ New Features:
 Fixes:
 
 - fixed misc. crashes
+- fixed Domain.generate_ns_secret() storing bytes object into Domain.nameserver_update_secret leading to trying to insert the string representation of the bytes object, so 91 characters in a varchar(88)
 
 Other changes:
 

--- a/src/nsupdate/main/models.py
+++ b/src/nsupdate/main/models.py
@@ -141,7 +141,7 @@ class Domain(models.Model):
         user_model = get_user_model()
         secret = user_model.objects.make_random_password(length=bitlength // 8)
         secret = secret.encode('utf-8')
-        self.nameserver_update_secret = secret_base64 = base64.b64encode(secret)
+        self.nameserver_update_secret = secret_base64 = base64.b64encode(secret).decode('utf-8')
         self.save()
         return secret_base64
 


### PR DESCRIPTION
Relates to #453 