### PR TITLE
Include note about IPv4 interface ID

### DIFF
--- a/docs/user.rst
+++ b/docs/user.rst
@@ -216,8 +216,8 @@ Note:
   make sure you send this device's IPv6 address with the update (myip=...) or
   run the updater on that device and make sure the request originates from
   the IPv6 address you want in DNS.
-* if you want to have all IPv4 addresses point to the same IP address from the
-  router, use 0 as the interface ID.
+* if you want the related host to point to the same IPv4 address as the main
+  host (which is often the router), use 0 as the interface ID.
 
 
 Other Services Updaters

--- a/docs/user.rst
+++ b/docs/user.rst
@@ -216,6 +216,8 @@ Note:
   make sure you send this device's IPv6 address with the update (myip=...) or
   run the updater on that device and make sure the request originates from
   the IPv6 address you want in DNS.
+* if you want to have all IPv4 addresses point to the same IP address from the
+  router, use 0 as the interface ID.
 
 
 Other Services Updaters


### PR DESCRIPTION
The documentation was unclear how I can have the same IPv4 address for a related host. I found the solution in #133 and I thought it might help others to include this into the documentation.