### PR TITLE
Support ipprefix via argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ New Features:
   without causing database accesses.
 - django-admin faults: show/reset api auth faults counter
 - add api_auth_faults column to django admin's Hosts view
+- support ipprefix argument to pass the netmask and prefix for related domains explicitly
 
 Fixes:
 
@@ -327,7 +328,7 @@ Other changes:
   you can use custom templates for this)
 * added some ugly logos (if you can do better ones, please help)
   https://github.com/nsupdate-info/nsupdate.info/issues/78
-* replaced "SSL" by "TLS" everywhere.      
+* replaced "SSL" by "TLS" everywhere.
   SSL is the old/outdated name. Since 1999, it's called TLS.
 * updated to latest versions on CDN: jquery, bootstrap, font-awesome
 

--- a/src/nsupdate/main/templates/main/includes/tabbed_router_configuration.html
+++ b/src/nsupdate/main/templates/main/includes/tabbed_router_configuration.html
@@ -125,7 +125,7 @@
         </table>
         <h5>{% trans "If you have IPv4 and IPv6" %}</h5>
         {% trans "Set Update-URL to the following (two URLs, separated by one space)" %}
-        <div class="well well-sm">https://{{ WWW_IPV4_HOST }}/nic/update https://{{ WWW_IPV6_HOST }}/nic/update</div>
+        <div class="well well-sm">https://{{ WWW_IPV4_HOST }}/nic/update https://{{ WWW_IPV6_HOST }}/nic/update?ipprefix=&lt;ip6lanprefix&gt;</div>
         <h5>{% trans "Forcing a dynamic DNS update" %}</h5>
         {% trans "If you want to force a dynamic update for testing purposes, you can do it like this:" %}
         <ul>


### PR DESCRIPTION
Allow an extra argument `ipprefix` for both ipv4 and ipv6 to pass a separate prefix, like often for IPv6 connections where one gets a main ipv6 for the router and a subnet for the internal network.

Passing the ipprefix will also override the default netmask from the config.

Fixes #353