### PR TITLE
Update user.rst to add ipv6 support for ddclient

### DIFF
--- a/docs/user.rst
+++ b/docs/user.rst
@@ -360,7 +360,7 @@ Here are some clients that likely qualify:
 
   - we offer configuration help for it, just copy & paste
   - good working, reliable
-  - the official version is IPv4 only, IPv6 support needs a patched version
+  - IPv4 and IPv6 support
   - Linux & other POSIX systems
 * inadyn (>= 1.99.11)
 


### PR DESCRIPTION
ddclient added the ipv6 without patch in 3.8.1, as said on the web interface (https://github.com/nsupdate-info/nsupdate.info/blob/8c391cca886522762663371fd75238c9dae93c38/src/nsupdate/main/templates/main/includes/tabbed_router_configuration.html#L175).

Almost all distributions (if not all) have a version greater than 3.8.1. Thus, the documentation can be updated to reflect the current support of ipv6.