### PR TITLE
Fix connectivity test when editing domains (again)

### DIFF
--- a/src/nsupdate/main/forms.py
+++ b/src/nsupdate/main/forms.py
@@ -74,7 +74,7 @@ class EditDomainForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super(EditDomainForm, self).clean()
 
-        if self.cleaned_data['available']:
+        if self.cleaned_data['available'] and 'nameserver_ip' in cleaned_data:
             try:
                 check_domain(self.instance.name, cleaned_data['nameserver_ip'])
 


### PR DESCRIPTION
Follow-up to #492 to fix #523

Same procedure as last year:

> **UNTESTED CHANGES** <ins>(again)</ins>**!** I <ins>still</ins> have never worked with Django, nor do I run my own nsupdate.info instance. Unfortunately I <ins>still</ins> don't have enough time to set things up to test the changes I made. The changes are rather trivial, so I'm rather confident that they should do the trick <ins>(I've said that before... I was wrong... Maybe I'm right now? :see_no_evil:)</ins>, but they need testing nevertheless. I believe that providing this patch is better than nothing, even if this PR is considered unmergeable - it at least gives some hints about what the issue might be with <del>#479</del> <ins>#523</ins>.

I **assume** that Django is going to reject the invalid `nameserver_ip` later anyway, so we can simply skip `check_domain()` if no (valid) `nameserver_ip` is given. But I truly don't know, checking would require me to set up a local dev environment, something I unfortunately just don't have enough time for :disappointed: Providing a patch is better than nothing, even though this patch probably isn't really worth the work...

No addition to the changelog since it's fixing an unreleased previous change.

Fixes #523