### PR TITLE
Update generated inadyn.conf for IPv6 support

### DIFF
--- a/src/nsupdate/main/templates/main/includes/tabbed_router_configuration.html
+++ b/src/nsupdate/main/templates/main/includes/tabbed_router_configuration.html
@@ -287,6 +287,7 @@ system ipv4@nsupdate.info
 period       = 300
 
 # use either ipv4 or ipv6 configuration below
+# IPv4 support
 #provider ipv4@nsupdate.info {
 #    ssl      = true
 #    username = {{ host.get_fqdn|default:"&lt;your hostname&gt;" }}
@@ -294,14 +295,12 @@ period       = 300
 #    hostname = {{ host.get_fqdn|default:"&lt;your hostname&gt;" }}
 #}
 
-# IPv6 supported in inadyn, but no pre-defined provider
-custom ipv6@nsupdate.info {
+# IPv6 support
+provider ipv6@nsupdate.info {
     ssl      = true
     username = {{ host.get_fqdn|default:"&lt;your hostname&gt;" }}
     password = {{ update_secret|default:"&lt;your secret&gt;" }}
     hostname = {{ host.get_fqdn|default:"&lt;your hostname&gt;" }}
-    ddns-server = {{ WWW_IPV6_HOST }}
-    ddns-path = "/nic/update?hostname=%h&myip=%i"
 }
 
 </pre>

--- a/src/nsupdate/main/templates/main/includes/tabbed_router_configuration.html
+++ b/src/nsupdate/main/templates/main/includes/tabbed_router_configuration.html
@@ -281,19 +281,29 @@ system ipv4@nsupdate.info
 
 # note: no IPv6 support in inadyn yet.
 </pre>
-        <h4>inadyn ({% trans "verified with" %} 2.1)</h4>
+        <h4>inadyn ({% trans "verified with" %} 2.10.0)</h4>
         <pre># /etc/inadyn.conf
 
 period       = 300
 
-provider ipv4@nsupdate.info {
+# use either ipv4 or ipv6 configuration below
+#provider ipv4@nsupdate.info {
+#    ssl      = true
+#    username = {{ host.get_fqdn|default:"&lt;your hostname&gt;" }}
+#    password = {{ update_secret|default:"&lt;your secret&gt;" }}
+#    hostname = {{ host.get_fqdn|default:"&lt;your hostname&gt;" }}
+#}
+
+# IPv6 supported in inadyn, but no pre-defined provider
+custom ipv6@nsupdate.info {
     ssl      = true
     username = {{ host.get_fqdn|default:"&lt;your hostname&gt;" }}
     password = {{ update_secret|default:"&lt;your secret&gt;" }}
     hostname = {{ host.get_fqdn|default:"&lt;your hostname&gt;" }}
+    ddns-server = {{ WWW_IPV6_HOST }}
+    ddns-path = "/nic/update?hostname=%h&myip=%i"
 }
 
-# note: no IPv6 support in inadyn yet.
 </pre>
     </div>
     <div class="tab-pane" id="openwrt">

--- a/src/nsupdate/main/templates/main/includes/tabbed_router_configuration.html
+++ b/src/nsupdate/main/templates/main/includes/tabbed_router_configuration.html
@@ -281,19 +281,19 @@ system ipv4@nsupdate.info
 
 # note: no IPv6 support in inadyn yet.
 </pre>
-        <h4>inadyn ({% trans "verified with" %} 2.10.0)</h4>
+        <h4>inadyn ({% trans "verified with" %} 2.11.0)</h4>
         <pre># /etc/inadyn.conf
 
 period       = 300
 
-# use either ipv4 or ipv6 configuration below
+# use ipv4 and/or ipv6 configuration below
 # IPv4 support
-#provider ipv4@nsupdate.info {
-#    ssl      = true
-#    username = {{ host.get_fqdn|default:"&lt;your hostname&gt;" }}
-#    password = {{ update_secret|default:"&lt;your secret&gt;" }}
-#    hostname = {{ host.get_fqdn|default:"&lt;your hostname&gt;" }}
-#}
+provider ipv4@nsupdate.info {
+    ssl      = true
+    username = {{ host.get_fqdn|default:"&lt;your hostname&gt;" }}
+    password = {{ update_secret|default:"&lt;your secret&gt;" }}
+    hostname = {{ host.get_fqdn|default:"&lt;your hostname&gt;" }}
+}
 
 # IPv6 support
 provider ipv6@nsupdate.info {


### PR DESCRIPTION
inadyn 2.10 supports IPv6. The tabbed_router_configuration is extended to show IPv6 configuration of inadyn (plus IPv4 configuration commented out to be activated if required).