### PR TITLE
Fix ssrf validation

### DIFF
--- a/src/nsupdate/main/forms.py
+++ b/src/nsupdate/main/forms.py
@@ -4,6 +4,7 @@ form definitions (which fields are available, order, autofocus, ...)
 """
 
 import binascii
+import ipaddress
 
 from django import forms
 from django.utils.translation import gettext_lazy as _
@@ -70,10 +71,31 @@ class EditDomainForm(forms.ModelForm):
         except (binascii.Error, UnicodeEncodeError):
             raise forms.ValidationError(_("Enter a valid secret in base64 format."), code='invalid')
         return secret
+    
+    def clean_nameserver_ip(self):
+        """
+        Validate that nameserver_ip is a valid public IP address.
+        Reject private, loopback, reserved, and link-local addresses.
+        """
+        nameserver_ip = self.cleaned_data.get('nameserver_ip')
+        if not nameserver_ip:
+            return nameserver_ip
+
+        try:
+            ip_obj = ipaddress.ip_address(nameserver_ip)
+        except ValueError:
+            raise forms.ValidationError(_("Enter a valid IP address."), code='invalid')
+        
+        if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_reserved or ip_obj.is_link_local:
+            raise forms.ValidationError(("Enter a public IP address. Internal addresses are not allowed."), 
+                code='invalid'
+            )
+        return nameserver_ip
+
 
     def clean(self):
         cleaned_data = super(EditDomainForm, self).clean()
-
+        
         if self.cleaned_data['available'] and 'nameserver_ip' in cleaned_data:
             try:
                 check_domain(self.instance.name, cleaned_data['nameserver_ip'])


### PR DESCRIPTION
### Summary

This pull request addresses a potential Server-Side Request Forgery (SSRF) vulnerability in the `EditDomainForm.clean()` method.

### Details

Currently, the form accepts arbitrary `nameserver_ip` inputs, which are passed to the `check_domain()` function. This leads to dynamic DNS update attempts to the specified IP address, including internal ones (e.g., 127.0.0.1). As a result, attackers could potentially:

- Probe internal network services
- Interact with unintended internal DNS servers
- Perform SSRF attacks using the application's backend

### Fix

This patch adds validation using Python’s `ipaddress` module to reject loopback, private, and reserved IP addresses before performing any DNS update.

### Impact

This prevents misuse of the DNS update mechanism and mitigates the risk of SSRF attacks via internal IP injection.