### PR TITLE
docs fixes: docs/_build gitignored, added sphinx extension to make la…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ local_settings.py
 *.sqlite
 *.egg-info
 dist/
+docs/_build/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ import os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.viewcode']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.viewcode', 'sphinx.ext.imgconverter']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
`make pdflatex`  gives errors like these:

`/home/phorvath/priv/lich/nsupdate/work/nsupdate/README.rst:15: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://readthedocs.org/projects/nsupdateinfo/badge/?version=stable)
/home/phorvath/priv/lich/nsupdate/work/nsupdate/README.rst:19: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://github.com/nsupdate-info/nsupdate.info/workflows/CI/badge.svg?branch=master)
/home/phorvath/priv/lich/nsupdate/work/nsupdate/README.rst:23: WARNING: a suitable image for latex builder not found: ['image/svg+xml'] (https://codecov.io/gh/nsupdate-info/nsupdate.info/branch/master/graph/badge.svg?token=3qFlVUxINM)

! LaTeX Error: Unknown graphics extension: .svg.
`

The cause was that a sphinx extension in missing in `docs/conf.py` .

Beside that, `docs/_build`, as being a work directory and having only generated files, should be gitignored.