### PR TITLE
pip-generated src/version/_version.py is now gitignored. vim/idea tem…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,16 @@
 *.pyc
 local_settings.py
 .coverage
-.idea/
 .cache/
 .tox/
 *.sqlite
 *.egg-info
 dist/
 docs/_build/
+src/nsupdate/_version.py
+
+# idea
+.idea/
+
+# vi(m)
+.*.sw?


### PR DESCRIPTION
…porary files are gitignored.

src/version/_version.py is generated by the `pip install -e .` install command. As an automatically generated file, there is no reason be part of the source.

Beside that, temporary files of various dev envionments should be also ignored and these ignore be commented (to keep a better understand, what is ignored and why. Devs mostly do not know the temp files of other editors).