### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@
 
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/nsupdate-info/nsupdate.info/security/code-scanning/2](https://github.com/nsupdate-info/nsupdate.info/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml`, directly under `name` (or before `jobs`).  
Use least privilege needed by current steps:

- `contents: read` (required for `actions/checkout`)
  
No other write scopes are needed based on the shown jobs. This preserves existing behavior while making token permissions explicit and future-proof.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
