### PR TITLE
Fix IP detection by using .append() instead of .add()

### DIFF
--- a/src/nsupdate/templates/base.html
+++ b/src/nsupdate/templates/base.html
@@ -171,11 +171,11 @@
                 <script type="text/javascript">
                 $(document).ready(function() {
                     {% if not request.session.ipv4 %}
-                        $('#ip_detection').add(
+                        $('#ip_detection').append(
                             '<img src="//{{ WWW_IPV4_HOST }}/detectip/{{ detectip_token }}/" >');
                     {% endif %}
                     {% if not request.session.ipv6 %}
-                        $('#ip_detection').add(
+                        $('#ip_detection').append(
                             '<img src="//{{ WWW_IPV6_HOST }}/detectip/{{ detectip_token }}/" >');
                     {% endif %}
                     function insert_ips() {


### PR DESCRIPTION
The jQuery `.add()` method only adds elements to a jQuery object, it doesn't insert them into the DOM.

Changing it to `.append()` ensures the fake images are actually loaded by the browser for IP detection.