### PR TITLE
Fix related host processing on network-prefix updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ permissions:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ 0.13-maint ]
     paths:
     - '**.py'
     - '**.yml'
@@ -16,7 +16,7 @@ on:
     - 'requirements.d/*'
     - '!docs/**'
   pull_request:
-    branches: [ master ]
+    branches: [ 0.13-maint ]
     paths:
     - '**.py'
     - '**.yml'

--- a/src/nsupdate/api/views.py
+++ b/src/nsupdate/api/views.py
@@ -431,7 +431,7 @@ def _update_or_delete(host, ipaddr, secure=False, logger=None, _delete=False):
     :param _delete: True for delete, False for update
     :return: dyndns2 response string
     """
-    mode = ('update', 'delete')[_delete]
+    mode = ('update', 'delete')[_delete]  # only use this for logging
     # we are doing abuse / available checks rather late, so the client might
     # get more specific responses (like 'badagent' or 'notfqdn') by earlier
     # checks. it also avoids some code duplication if done here:
@@ -472,10 +472,14 @@ def _update_or_delete(host, ipaddr, secure=False, logger=None, _delete=False):
             single_ip = netmask == 128  # rather theoretical case, but who knows...
         else:
             raise ValueError('unknown ip address kind: %s' % kind)
-        if not single_ip and IPNetwork("%s/%d" % (ipaddr, netmask)).network == IPAddress(ipaddr):
-            _delete = True
+        # we do not want to update A/AAAA records with network addresses:
+        is_network = not single_ip and IPNetwork("%s/%d" % (ipaddr, netmask)).network == IPAddress(ipaddr)
+        if is_network:
+            logger.info('%s - received %s for host %s, but address has only network prefix, deleting instead' % (fqdn, mode, ipaddr, ))
+    else:
+        is_network = False
 
-    if mode == 'update' and IPAddress(ipaddr) in settings.BAD_IPS_HOST:
+    if not _delete and IPAddress(ipaddr) in settings.BAD_IPS_HOST:
         msg = '%s - received %s to blacklisted ip address: %r' % (fqdn, mode, ipaddr)
         logger.warning(msg)
         host.abuse = True
@@ -484,7 +488,7 @@ def _update_or_delete(host, ipaddr, secure=False, logger=None, _delete=False):
         return 'abuse'
     host.poke(kind, secure)
     try:
-        if _delete:
+        if _delete or is_network:
             delete(fqdn, rdtype)
         else:
             update(fqdn, ipaddr)


### PR DESCRIPTION
Updates containing pure network prefixes previously set the `_delete` flag to remove the main host, but this incorrectly skipped processing related hosts.

This adds an `is_network` flag to safely separate the "is network prefix" check from explicit `/nic/delete` requests, ensuring `_on_update_success` is executed to apply the new network prefix to all related hosts.

Fixes #671.