### PR TITLE
security: change state-changing "Show Configuration" to POST, fixes #265

### DIFF
--- a/src/nsupdate/main/_tests/test_main.py
+++ b/src/nsupdate/main/_tests/test_main.py
@@ -64,12 +64,12 @@ def test_views_logged_in(client):
         ('robots', dict(), 200),
         ('status', dict(), 200),
         ('overview', dict(), 200),
-        ('generate_secret_view', dict(pk=1), 200),
-        ('generate_secret_view', dict(pk=2), 404),
-        ('generate_secret_view', dict(pk=100), 404),
-        ('generate_ns_secret_view', dict(pk=1), 200),
-        ('generate_ns_secret_view', dict(pk=2), 404),
-        ('generate_ns_secret_view', dict(pk=100), 404),
+        ('generate_secret_view', dict(pk=1), 405),
+        ('generate_secret_view', dict(pk=2), 405),
+        ('generate_secret_view', dict(pk=100), 405),
+        ('generate_ns_secret_view', dict(pk=1), 405),
+        ('generate_ns_secret_view', dict(pk=2), 405),
+        ('generate_ns_secret_view', dict(pk=100), 405),
         ('host_view', dict(pk=1), 200),
         ('host_view', dict(pk=2), 404),
         ('host_view', dict(pk=100), 404),
@@ -121,3 +121,10 @@ def test_views_logged_in(client):
     response = client.post(reverse('update_related_hosts', kwargs=dict(mpk=1)))
     assert response.status_code == 302
     assert response.url == reverse('related_host_overview', args=(1,))
+
+    for view, kwargs in [
+        ('generate_secret_view', dict(pk=1)),
+        ('generate_ns_secret_view', dict(pk=1)),
+    ]:
+        response = client.post(reverse(view, kwargs=kwargs))
+        assert response.status_code == 200

--- a/src/nsupdate/main/templates/main/domain.html
+++ b/src/nsupdate/main/templates/main/domain.html
@@ -51,7 +51,8 @@
                         You have to use the new secret in your name server configuration.
                         {% endblocktrans %}
                     </p>
-                    <form action="{% url 'generate_ns_secret_view' domain.pk %}" method="get">
+                    <form action="{% url 'generate_ns_secret_view' domain.pk %}" method="post">
+                        {% csrf_token %}
                         <button type="submit" class="btn btn-primary btn-warning">{% trans "Show Configuration" %}</button>
                     </form>
                 </div>

--- a/src/nsupdate/main/templates/main/host.html
+++ b/src/nsupdate/main/templates/main/host.html
@@ -54,7 +54,8 @@
                         You have to use the new secret in your router / update client configuration.
                         {% endblocktrans %}
                     </p>
-                    <form action="{% url 'generate_secret_view' host.pk %}" method="get">
+                    <form action="{% url 'generate_secret_view' host.pk %}" method="post">
+                        {% csrf_token %}
                         <button type="submit" class="btn btn-primary btn-warning">{% trans "Show Configuration" %}</button>
                     </form>
                 </div>

--- a/src/nsupdate/main/views.py
+++ b/src/nsupdate/main/views.py
@@ -10,7 +10,7 @@ import dns.name
 from django.db.models import Q
 from django.views.generic import View, TemplateView, CreateView, DetailView
 from django.views.generic.edit import UpdateView, DeleteView
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, HttpResponseNotAllowed
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import get_user_model
 from django.contrib import messages
@@ -47,12 +47,20 @@ class GenerateSecretView(DetailView):
             raise Http404
         return obj
 
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        # generate secret, store it hashed and return the plain secret for the context
+        update_secret = self.object.generate_secret()
+        messages.add_message(self.request, messages.SUCCESS, 'Host secret created.')
+        context = self.get_context_data(object=self.object, update_secret=update_secret)
+        return self.render_to_response(context)
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponseNotAllowed(['POST'])
+
     def get_context_data(self, **kwargs):
         context = super(GenerateSecretView, self).get_context_data(**kwargs)
         context['nav_overview'] = True
-        # generate secret, store it hashed and return the plain secret for the context
-        context['update_secret'] = self.object.generate_secret()
-        messages.add_message(self.request, messages.SUCCESS, 'Host secret created.')
         return context
 
 
@@ -70,11 +78,19 @@ class GenerateNSSecretView(DetailView):
             raise Http404
         return obj
 
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        shared_secret = self.object.generate_ns_secret()
+        messages.add_message(self.request, messages.SUCCESS, 'Nameserver shared secret created.')
+        context = self.get_context_data(object=self.object, shared_secret=shared_secret)
+        return self.render_to_response(context)
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponseNotAllowed(['POST'])
+
     def get_context_data(self, **kwargs):
         context = super(GenerateNSSecretView, self).get_context_data(**kwargs)
         context['nav_overview'] = True
-        context['shared_secret'] = self.object.generate_ns_secret()
-        messages.add_message(self.request, messages.SUCCESS, 'Nameserver shared secret created.')
         return context
 
 


### PR DESCRIPTION
- Fix: Prevent secret generation via GET requests in GenerateSecretView and GenerateNSSecretView.
- Update host.html and domain.html to use POST forms with CSRF tokens.
- Update tests to verify that GET returns 405 and POST succeeds.