### PR TITLE
minor margin between buttons

### DIFF
--- a/src/nsupdate/static/css/nsupdate.css
+++ b/src/nsupdate/static/css/nsupdate.css
@@ -286,3 +286,7 @@ body, p, li, td, th {
 .table-striped>tbody>tr:nth-of-type(odd)>* {
     color: var(--text-primary);
 }
+
+.btn-group {
+    margin: 0.1em;
+}


### PR DESCRIPTION
That could look a bit better:

<img width="623" height="245" alt="Bildschirmfoto vom 2026-05-01 13-57-40" src="https://github.com/user-attachments/assets/c27b9329-0578-4ef5-aba4-b3fe394bee3c" />

My suggestion is this:

<img width="623" height="245" alt="Bildschirmfoto vom 2026-05-01 13-57-53" src="https://github.com/user-attachments/assets/0ad55321-11e6-4f2d-bf4d-c0d466b7af67" />