### PR TITLE
fix bind9 zone template

### DIFF
--- a/src/nsupdate/main/templates/main/generate_ns_secret.html
+++ b/src/nsupdate/main/templates/main/generate_ns_secret.html
@@ -74,6 +74,12 @@ $TTL 3600       ; 1 hour
                         MX      10 mail.{{ object.name }}.
 $ORIGIN {{ object.name }}.
 $TTL 3600       ; 1 hour
+
+ns1                    A        1.2.3.4
+                       AAAA     ::1
+ns2                    A        1.2.3.4
+                       AAAA     ::1
+
 ; note: the www, ipv4, ipv6 host entries are ONLY needed if you run the
 ; nsupdate.info service on these hosts. if you just want to add another
 ; domain that can be updated from an existing nsupdate.info service, you

--- a/src/nsupdate/main/templates/main/generate_ns_secret.html
+++ b/src/nsupdate/main/templates/main/generate_ns_secret.html
@@ -32,7 +32,7 @@ key "{{ object.name }}." {
     secret "{{ shared_secret }}";
 };
 
-zone {{ object.name }} {
+zone "{{ object.name }}." {
         type master;
         // bind9 needs write permissions into that directory and into that file:
         file "/etc/bind/zones/{{ object.name }}";


### PR DESCRIPTION
When setting up a new zone, for example in development, the given example zone-files would not load because they lack `ns1`/`ns2` records. Also, the quoting and dotting was different between the `key` and the `zone`-section in the `named.conf` which would probably work anyway but looked like a unnecessary difference to me.