### PR TITLE
test container can be built on architectures not loved by pip enough well

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.11-alpine
 WORKDIR /app
 
-RUN apk add bind git
+RUN apk add bind git rustc-dev cargo openssl-dev pkgconf
 COPY bind/named.conf.local /etc/bind/named.conf.local
 COPY bind/zones/ /var/lib/bind/pri/
 RUN chown named -R /var/lib/bind/pri/
+RUN git config --global --add safe.directory /app
 
 CMD /app/scripts/docker/test.sh


### PR DESCRIPTION
The test container builder installs various pip dependencies for the project. Some of them (particularly: cryptography) have also binary parts. On more popular architectures, these can be downloaded. In others, these are compiled.

If these are compiled (particularly: armhf, i386, any non-intel-and-non-arm), they have compile dependencies. This PR adds these compile dependencies.

It increases a bit the nsupdate tester image size, but not much.