### PR TITLE
ux improvements: related hosts

### DIFF
--- a/src/nsupdate/api/_tests/test_api.py
+++ b/src/nsupdate/api/_tests/test_api.py
@@ -1,10 +1,11 @@
 """
 Tests for the API package.
 """
-
+import dns.resolver
 import pytest
 
 import base64
+
 from netaddr import IPSet, IPAddress
 
 from django.urls import reverse
@@ -193,6 +194,18 @@ def test_nic_update_authorized_update_other_services(client):
     assert query_ns(TEST_HOST_OTHER, 'A') == '2.3.4.5'
 
 
+@pytest.mark.requires_sequential
+def test_nic_delete_authorized_update_other_services(client):
+    response = client.get(reverse('nic_update') + '?myip=1.2.3.4',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST_OTHER, 'A') == '1.2.3.4'
+    response = client.get(reverse('nic_delete') + '?myip=0.0.0.0',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST_OTHER, 'A') == '0.0.0.0'
+
+
 def test_nic_update_authorized_badagent(client, settings):
     settings.BAD_AGENTS = ['foo', 'bad_agent', 'bar', ]
     response = client.get(reverse('nic_update'),
@@ -284,6 +297,40 @@ def test_nic_delete_authorized(client):
     assert response.content == b'deleted AAAA'
 
 
+def test_nic_delete_authorized_also_deletes_related_hosts(client):
+    # setup host v4
+    response = client.get(reverse('nic_update') + '?myip=%s' % ('1.2.3.4', ),
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST, 'A') == '1.2.3.4'
+    assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.1'  # 1.2.3.4/29 + 0.0.0.1
+
+    # setup host v6
+    response = client.get(reverse('nic_update') + '?myip=%s' % ('2001::1', ),
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST, 'AAAA') == '2001::1'
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001::1'  # 2001::3/64 + ::1
+
+    # delete host v4
+    response = client.get(reverse('nic_delete') + '?myip=%s' % ('0.0.0.0', ),
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    with pytest.raises(dns.resolver.NoAnswer):
+        assert query_ns(TEST_HOST, 'A') is None, "did not delete related-host A record"
+    with pytest.raises(dns.resolver.NoAnswer):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None, "did not delete related-host A record"
+
+    # delete host v6
+    response = client.get(reverse('nic_delete') + '?myip=%s' % ('::', ),
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST, 'AAAA') is None, "did not delete main-host AAAA record"
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'AAAA') is None, "did not delete related-host AAAA record"
+
+
 def test_nic_delete_session(client):
     client.login(username=USERNAME, password=PASSWORD)
     response = client.get(reverse('nic_update_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '1.2.3.4'))
@@ -296,6 +343,35 @@ def test_nic_delete_session(client):
     response = client.get(reverse('nic_delete_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '::'))
     assert response.status_code == 200
     assert response.content == b'deleted AAAA'
+
+
+def test_nic_delete_session_also_deletes_related_hosts(client):
+    client.login(username=USERNAME, password=PASSWORD)
+    response = client.get(reverse('nic_update_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '1.2.3.4'))
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST, 'A') == '1.2.3.4'
+    assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.1'  # 1.2.3.4/29 + 0.0.0.1
+
+    response = client.get(reverse('nic_update_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '2080::1:1'))
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST, 'AAAA') == '2080::1:1'
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2080::1'  # 2080::1:1/64 + ::1
+
+    response = client.get(reverse('nic_delete_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '0.0.0.0'))
+    assert response.status_code == 200
+    assert response.content == b'deleted A'
+    with pytest.raises(dns.resolver.NoAnswer):
+        assert query_ns(TEST_HOST, 'A') is None, "did not delete related-host A record"
+    with pytest.raises(dns.resolver.NoAnswer):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None, "did not delete related-host A record"
+
+    response = client.get(reverse('nic_delete_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '::'))
+    assert response.status_code == 200
+    assert response.content == b'deleted AAAA'
+    with pytest.raises(dns.resolver.NXDOMAIN):  # this was the last record, so now the domain is fully gone
+        assert query_ns(TEST_HOST, 'AAAA') is None, "did not delete main-host AAAA record"
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'AAAA') is None, "did not delete related-host AAAA record"
 
 
 def test_detect_ip_invalid_session(client):

--- a/src/nsupdate/api/_tests/test_api.py
+++ b/src/nsupdate/api/_tests/test_api.py
@@ -420,6 +420,30 @@ def test_nic_update_multiple_ips(client):
     assert content == f'good {v4_new}\nnochg {v6}'
 
 
+def test_nic_update_multiple_ips_updates_related_hosts(client):
+    v4 = '1.2.3.4'
+    v6 = '2001:db8::10'
+    response = client.get(reverse('nic_update') + f'?myip={v4},{v6}',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST, 'A') == '1.2.3.4'
+    assert query_ns(TEST_HOST, 'AAAA') == '2001:db8::10'
+    assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.1'
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001:db8::1'
+
+    v4 = '4.3.2.1'
+    v6 = '2001:8db::10'
+    response = client.get(reverse('nic_update') + f'?myip={v4},{v6}',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST, 'A') == '4.3.2.1'
+    assert query_ns(TEST_HOST, 'AAAA') == '2001:8db::10'
+    assert query_ns(TEST_HOST_RELATED, 'A') == '4.3.2.1'
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001:8db::1'
+
+
 def test_nic_delete_multiple_ips(client):
     # Test with multiple IPs (v4 and v6) for deletion
     v4 = '1.2.3.4'
@@ -436,3 +460,26 @@ def test_nic_delete_multiple_ips(client):
     if content == 'dnserr':
         pytest.skip("DNS server not available in test environment")
     assert content == 'deleted A,AAAA'
+
+
+def test_nic_delete_multiple_ips_deletes_related_hosts(client):
+    v4 = '4.3.2.1'
+    v6 = '2001:8db::10'
+    response = client.get(reverse('nic_update') + f'?myip={v4},{v6}',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+
+    assert response.status_code == 200
+
+    v4 = '0.0.0.0'
+    v6 = '::'
+    response = client.get(reverse('nic_delete') + f'?myip={v4},{v6}',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST, 'A') is None
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST, 'AAAA') is None
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'AAAA') is None

--- a/src/nsupdate/api/views.py
+++ b/src/nsupdate/api/views.py
@@ -515,70 +515,80 @@ def _update_or_delete(host, ipaddr, secure=False, logger=None, _delete=False):
             # XXX unclear what to do for "other services" we relay updates to
             return 'deleted %s' % rdtype
         else:  # update
-            _on_update_success(host, fqdn, kind, ipaddr, secure, logger)
+            _update_related_hosts(host, kind, ipaddr, secure, logger)
             return 'good %s' % ipaddr
 
 
-def _on_update_success(host, fqdn, kind, ipaddr, secure, logger):
+def _update_related_hosts(host, kind, ipaddr, secure, logger):
     """after updating the host in dns, do related other updates"""
     # update related hosts
-    rdtype = 'A' if kind == 'ipv4' else 'AAAA'
     for rh in host.relatedhosts.all():
-        if rh.available:
-            if kind == 'ipv4':
-                ifid = rh.interface_id_ipv4
-                netmask = host.netmask_ipv4
-            else:  # kind == 'ipv6':
-                ifid = rh.interface_id_ipv6
-                netmask = host.netmask_ipv6
-            ifid = ifid.strip() if ifid else ifid
-            _delete = not ifid  # leave ifid empty if you don't want this rh record
-            try:
-                rh_fqdn = FQDN(rh.name + '.' + fqdn.host, fqdn.domain)
-                if not _delete:
-                    ifid = IPAddress(ifid)
-                    network = IPNetwork("%s/%d" % (ipaddr, netmask))
-                    rh_ipaddr = str(IPAddress(network.network) + int(ifid))
-            except (IndexError, AddrFormatError, ValueError) as e:
-                logger.warning("trouble computing address of related host %s [%s]" % (rh, e))
-            else:
-                if not _delete:
-                    logger.info("updating related host %s -> %s" % (rh_fqdn, rh_ipaddr))
-                else:
-                    logger.info("deleting related host %s" % (rh_fqdn, ))
-                try:
-                    if not _delete:
-                        update(rh_fqdn, rh_ipaddr)
-                    else:
-                        delete(rh_fqdn, rdtype)
-                except SameIpError:
-                    msg = '%s - related hosts no-change update, ip: %s tls: %r' % (rh_fqdn, rh_ipaddr, secure)
-                    logger.warning(msg)
-                    host.register_client_result(msg, fault=True)
-                except (DnsUpdateError, NameServerNotAvailable) as e:
-                    msg = str(e)
-                    if not _delete:
-                        msg = '%s - related hosts update that resulted in a dns error [%s], ip: %s tls: %r' % (
-                            rh_fqdn, msg, rh_ipaddr, secure)
-                    else:
-                        msg = '%s - related hosts deletion that resulted in a dns error [%s], tls: %r' % (
-                            rh_fqdn, msg, secure)
-                    logger.error(msg)
-                    host.register_server_result(msg, fault=True)
+        _update_related_host(rh, kind, ipaddr, logger, secure)
 
     # now check if there are other services we shall relay updates to:
     for hc in host.serviceupdaterhostconfigs.all():
-        if (kind == 'ipv4' and hc.give_ipv4 and hc.service.accept_ipv4
-            or
-            kind == 'ipv6' and hc.give_ipv6 and hc.service.accept_ipv6):
-            kwargs = dict(
-                name=hc.name, password=hc.password,
-                hostname=hc.hostname, myip=ipaddr,
-                server=hc.service.server, path=hc.service.path, secure=hc.service.secure,
-            )
+        _update_service_updater_host(hc, kind, ipaddr, logger)
+
+
+def _update_service_updater_host(host_config, kind, ipaddr, logger):
+    if (kind == 'ipv4' and host_config.give_ipv4 and host_config.service.accept_ipv4
+        or
+        kind == 'ipv6' and host_config.give_ipv6 and host_config.service.accept_ipv6):
+        kwargs = dict(
+            name=host_config.name, password=host_config.password,
+            hostname=host_config.hostname, myip=ipaddr,
+            server=host_config.service.server, path=host_config.service.path, secure=host_config.service.secure,
+        )
+        try:
+            ddns_client.dyndns2_update(**kwargs)
+        except Exception:
+            # we never want to crash here
+            kwargs.pop('password')
+            logger.exception("the dyndns2 updater raised an exception [%r]" % kwargs)
+
+
+def _update_related_host(related_host, kind, ipaddr, logger, secure):
+    host = related_host.main_host
+    fqdn = host.get_fqdn()
+    rdtype = 'A' if kind == 'ipv4' else 'AAAA'
+    if related_host.available:
+        if kind == 'ipv4':
+            ifid = related_host.interface_id_ipv4
+            netmask = host.netmask_ipv4
+        else:  # kind == 'ipv6':
+            ifid = related_host.interface_id_ipv6
+            netmask = host.netmask_ipv6
+        ifid = ifid.strip() if ifid else ifid
+        _delete = not ifid  # leave ifid empty if you don't want this rh record
+        try:
+            rh_fqdn = FQDN(related_host.name + '.' + fqdn.host, fqdn.domain)
+            if not _delete:
+                ifid = IPAddress(ifid)
+                network = IPNetwork("%s/%d" % (ipaddr, netmask))
+                rh_ipaddr = str(IPAddress(network.network) + int(ifid))
+        except (IndexError, AddrFormatError, ValueError) as e:
+            logger.warning("trouble computing address of related host %s [%s]" % (related_host, e))
+        else:
+            if not _delete:
+                logger.info("updating related host %s -> %s" % (rh_fqdn, rh_ipaddr))
+            else:
+                logger.info("deleting related host %s" % (rh_fqdn,))
             try:
-                ddns_client.dyndns2_update(**kwargs)
-            except Exception:
-                # we never want to crash here
-                kwargs.pop('password')
-                logger.exception("the dyndns2 updater raised an exception [%r]" % kwargs)
+                if not _delete:
+                    update(rh_fqdn, rh_ipaddr)
+                else:
+                    delete(rh_fqdn, rdtype)
+            except SameIpError:
+                msg = '%s - related hosts no-change update, ip: %s tls: %r' % (rh_fqdn, rh_ipaddr, secure)
+                logger.warning(msg)
+                host.register_client_result(msg, fault=True)
+            except (DnsUpdateError, NameServerNotAvailable) as e:
+                msg = str(e)
+                if not _delete:
+                    msg = '%s - related hosts update that resulted in a dns error [%s], ip: %s tls: %r' % (
+                        rh_fqdn, msg, rh_ipaddr, secure)
+                else:
+                    msg = '%s - related hosts deletion that resulted in a dns error [%s], tls: %r' % (
+                        rh_fqdn, msg, secure)
+                logger.error(msg)
+                host.register_server_result(msg, fault=True)

--- a/src/nsupdate/api/views.py
+++ b/src/nsupdate/api/views.py
@@ -511,11 +511,10 @@ def _update_or_delete(host, ipaddr, secure=False, logger=None, _delete=False):
             msg = '%s - received good update -> ip: %s tls: %r' % (fqdn, ipaddr, secure)
         logger.info(msg)
         host.register_client_result(msg, fault=False)
+        _update_related_hosts(host, kind, ipaddr, secure, logger)
         if _delete:
-            # XXX unclear what to do for "other services" we relay updates to
             return 'deleted %s' % rdtype
         else:  # update
-            _update_related_hosts(host, kind, ipaddr, secure, logger)
             return 'good %s' % ipaddr
 
 
@@ -555,11 +554,15 @@ def _update_related_host(related_host, kind, ipaddr, logger, secure):
         if kind == 'ipv4':
             ifid = related_host.interface_id_ipv4
             netmask = host.netmask_ipv4
+            _delete = (ipaddr == '0.0.0.0')
         else:  # kind == 'ipv6':
             ifid = related_host.interface_id_ipv6
             netmask = host.netmask_ipv6
+            _delete = (ipaddr == '::')
         ifid = ifid.strip() if ifid else ifid
-        _delete = not ifid  # leave ifid empty if you don't want this rh record
+        if not ifid:
+            # leave ifid empty if you don't want this rh record
+            _delete = True
         try:
             rh_fqdn = FQDN(related_host.name + '.' + fqdn.host, fqdn.domain)
             if not _delete:


### PR DESCRIPTION
This PR improves the user experience when using related hosts, so that the result fits more closely to what one might naively expect. Especially it fixes these flows:
- deleting the ip of a main-host also deletes the ips of all related hosts (for v4 and v6 separately)
- deleting the ip of a main-host also deletes/nulls the ip of all service-update hosts

in a follow-up pr I intend to also fix the flows when updating/deleting the related hosts interface-ids.

I think this will fix #672 which you are also working on. Please pardon if I duplicated your work, I did not check beforehand.