### PR TITLE
ux improvements: related hosts - part 2

### DIFF
--- a/src/nsupdate/api/_tests/test_api.py
+++ b/src/nsupdate/api/_tests/test_api.py
@@ -1,10 +1,11 @@
 """
 Tests for the API package.
 """
-
+import dns.resolver
 import pytest
 
 import base64
+
 from netaddr import IPSet, IPAddress
 
 from django.urls import reverse
@@ -193,6 +194,18 @@ def test_nic_update_authorized_update_other_services(client):
     assert query_ns(TEST_HOST_OTHER, 'A') == '2.3.4.5'
 
 
+@pytest.mark.requires_sequential
+def test_nic_delete_authorized_update_other_services(client):
+    response = client.get(reverse('nic_update') + '?myip=1.2.3.4',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST_OTHER, 'A') == '1.2.3.4'
+    response = client.get(reverse('nic_delete') + '?myip=0.0.0.0',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST_OTHER, 'A') == '0.0.0.0'
+
+
 def test_nic_update_authorized_badagent(client, settings):
     settings.BAD_AGENTS = ['foo', 'bad_agent', 'bar', ]
     response = client.get(reverse('nic_update'),
@@ -284,6 +297,40 @@ def test_nic_delete_authorized(client):
     assert response.content == b'deleted AAAA'
 
 
+def test_nic_delete_authorized_also_deletes_related_hosts(client):
+    # setup host v4
+    response = client.get(reverse('nic_update') + '?myip=%s' % ('1.2.3.4', ),
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST, 'A') == '1.2.3.4'
+    assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.1'  # 1.2.3.4/29 + 0.0.0.1
+
+    # setup host v6
+    response = client.get(reverse('nic_update') + '?myip=%s' % ('2001::1', ),
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST, 'AAAA') == '2001::1'
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001::1'  # 2001::3/64 + ::1
+
+    # delete host v4
+    response = client.get(reverse('nic_delete') + '?myip=%s' % ('0.0.0.0', ),
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    with pytest.raises(dns.resolver.NoAnswer):
+        assert query_ns(TEST_HOST, 'A') is None, "did not delete related-host A record"
+    with pytest.raises(dns.resolver.NoAnswer):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None, "did not delete related-host A record"
+
+    # delete host v6
+    response = client.get(reverse('nic_delete') + '?myip=%s' % ('::', ),
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST, 'AAAA') is None, "did not delete main-host AAAA record"
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'AAAA') is None, "did not delete related-host AAAA record"
+
+
 def test_nic_delete_session(client):
     client.login(username=USERNAME, password=PASSWORD)
     response = client.get(reverse('nic_update_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '1.2.3.4'))
@@ -296,6 +343,35 @@ def test_nic_delete_session(client):
     response = client.get(reverse('nic_delete_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '::'))
     assert response.status_code == 200
     assert response.content == b'deleted AAAA'
+
+
+def test_nic_delete_session_also_deletes_related_hosts(client):
+    client.login(username=USERNAME, password=PASSWORD)
+    response = client.get(reverse('nic_update_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '1.2.3.4'))
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST, 'A') == '1.2.3.4'
+    assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.1'  # 1.2.3.4/29 + 0.0.0.1
+
+    response = client.get(reverse('nic_update_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '2080::1:1'))
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST, 'AAAA') == '2080::1:1'
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2080::1'  # 2080::1:1/64 + ::1
+
+    response = client.get(reverse('nic_delete_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '0.0.0.0'))
+    assert response.status_code == 200
+    assert response.content == b'deleted A'
+    with pytest.raises(dns.resolver.NoAnswer):
+        assert query_ns(TEST_HOST, 'A') is None, "did not delete related-host A record"
+    with pytest.raises(dns.resolver.NoAnswer):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None, "did not delete related-host A record"
+
+    response = client.get(reverse('nic_delete_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '::'))
+    assert response.status_code == 200
+    assert response.content == b'deleted AAAA'
+    with pytest.raises(dns.resolver.NXDOMAIN):  # this was the last record, so now the domain is fully gone
+        assert query_ns(TEST_HOST, 'AAAA') is None, "did not delete main-host AAAA record"
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'AAAA') is None, "did not delete related-host AAAA record"
 
 
 def test_detect_ip_invalid_session(client):

--- a/src/nsupdate/api/_tests/test_api.py
+++ b/src/nsupdate/api/_tests/test_api.py
@@ -1,20 +1,17 @@
 """
 Tests for the API package.
 """
-import dns.resolver
-import pytest
-
 import base64
 
+import dns.resolver
+import pytest
+from django.urls import reverse
 from netaddr import IPSet, IPAddress
 
-from django.urls import reverse
-
+from nsupdate.api.views import basic_authenticate
+from nsupdate.conftest import TESTDOMAIN, TEST_HOST, TEST_HOST_RELATED, TEST_HOST2, TEST_SECRET
 from nsupdate.main.dnstools import query_ns, FQDN
 from nsupdate.main.models import Domain
-from nsupdate.api.views import basic_authenticate
-
-from nsupdate.conftest import TESTDOMAIN, TEST_HOST, TEST_HOST_RELATED, TEST_HOST2, TEST_SECRET
 
 USERNAME = 'test'
 PASSWORD = 'pass'
@@ -70,7 +67,7 @@ def test_nic_update_authorized_nonexistent_host(client):
 
 
 def test_nic_update_authorized_foreign_host(client):
-    response = client.get(reverse('nic_update') + '?hostname=%s' % (TEST_HOST2, ),
+    response = client.get(reverse('nic_update') + '?hostname=%s' % (TEST_HOST2,),
                           HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
     assert response.status_code == 200
     # We must not get this updated; this is a host of some other user!
@@ -244,7 +241,7 @@ def test_nic_update_session_no_hostname(client):
 
 def test_nic_update_session(client):
     client.login(username=USERNAME, password=PASSWORD)
-    response = client.get(reverse('nic_update_authorized') + '?hostname=%s' % (TEST_HOST, ))
+    response = client.get(reverse('nic_update_authorized') + '?hostname=%s' % (TEST_HOST,))
     assert response.status_code == 200
     content = response.content.decode('utf-8')
     assert content.startswith('good ') or content.startswith('nochg ')
@@ -260,7 +257,7 @@ def test_nic_update_session_myip(client):
 
 def test_nic_update_session_foreign_host(client):
     client.login(username=USERNAME, password=PASSWORD)
-    response = client.get(reverse('nic_update_authorized') + '?hostname=%s' % (TEST_HOST2, ))
+    response = client.get(reverse('nic_update_authorized') + '?hostname=%s' % (TEST_HOST2,))
     assert response.status_code == 200
     # We must not get this updated; this is a host of some other user!
     assert response.content == b'nohost'
@@ -281,17 +278,17 @@ def test_nic_delete_authorized_invalid_ip2(client):
 
 
 def test_nic_delete_authorized(client):
-    response = client.get(reverse('nic_update') + '?myip=%s' % ('1.2.3.4', ),
+    response = client.get(reverse('nic_update') + '?myip=%s' % ('1.2.3.4',),
                           HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
     assert response.status_code == 200
-    response = client.get(reverse('nic_update') + '?myip=%s' % ('::1', ),
+    response = client.get(reverse('nic_update') + '?myip=%s' % ('::1',),
                           HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
     assert response.status_code == 200
-    response = client.get(reverse('nic_delete') + '?myip=%s' % ('0.0.0.0', ),
+    response = client.get(reverse('nic_delete') + '?myip=%s' % ('0.0.0.0',),
                           HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
     assert response.status_code == 200
     assert response.content == b'deleted A'
-    response = client.get(reverse('nic_delete') + '?myip=%s' % ('::', ),
+    response = client.get(reverse('nic_delete') + '?myip=%s' % ('::',),
                           HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
     assert response.status_code == 200
     assert response.content == b'deleted AAAA'
@@ -299,21 +296,21 @@ def test_nic_delete_authorized(client):
 
 def test_nic_delete_authorized_also_deletes_related_hosts(client):
     # setup host v4
-    response = client.get(reverse('nic_update') + '?myip=%s' % ('1.2.3.4', ),
+    response = client.get(reverse('nic_update') + '?myip=%s' % ('1.2.3.4',),
                           HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
     assert response.status_code == 200
     assert query_ns(TEST_HOST, 'A') == '1.2.3.4'
     assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.1'  # 1.2.3.4/29 + 0.0.0.1
 
     # setup host v6
-    response = client.get(reverse('nic_update') + '?myip=%s' % ('2001::1', ),
+    response = client.get(reverse('nic_update') + '?myip=%s' % ('2001::1',),
                           HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
     assert response.status_code == 200
     assert query_ns(TEST_HOST, 'AAAA') == '2001::1'
     assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001::1'  # 2001::3/64 + ::1
 
     # delete host v4
-    response = client.get(reverse('nic_delete') + '?myip=%s' % ('0.0.0.0', ),
+    response = client.get(reverse('nic_delete') + '?myip=%s' % ('0.0.0.0',),
                           HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
     assert response.status_code == 200
     with pytest.raises(dns.resolver.NoAnswer):
@@ -322,7 +319,7 @@ def test_nic_delete_authorized_also_deletes_related_hosts(client):
         assert query_ns(TEST_HOST_RELATED, 'A') is None, "did not delete related-host A record"
 
     # delete host v6
-    response = client.get(reverse('nic_delete') + '?myip=%s' % ('::', ),
+    response = client.get(reverse('nic_delete') + '?myip=%s' % ('::',),
                           HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
     assert response.status_code == 200
     with pytest.raises(dns.resolver.NXDOMAIN):
@@ -375,7 +372,7 @@ def test_nic_delete_session_also_deletes_related_hosts(client):
 
 
 def test_detect_ip_invalid_session(client):
-    response = client.get(reverse('detectip', args=('invalid_session_id', )))
+    response = client.get(reverse('detectip', args=('invalid_session_id',)))
     assert response.status_code == 204
 
 
@@ -479,6 +476,41 @@ def test_nic_delete_multiple_ips_deletes_related_hosts(client):
         assert query_ns(TEST_HOST, 'A') is None
     with pytest.raises(dns.resolver.NXDOMAIN):
         assert query_ns(TEST_HOST, 'AAAA') is None
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'AAAA') is None
+
+
+def test_nic_delete_also_deletes_related_host_ip(client):
+    # setup main host with v4 and v6
+    v4 = '1.2.3.4'
+    v6 = '2001:db8::10'
+    response = client.get(reverse('nic_update') + f'?myip={v4},{v6}',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+
+    assert response.status_code == 200
+
+    # expect the related host to resolve correctly
+    assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.1'
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001:db8::1'
+
+    # delete the v4 from the main host
+    response = client.get(reverse('nic_delete') + '?myip=0.0.0.0',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+
+    # expect the related host's v4 to be a NoAnswer and v6 to still resolve
+    with pytest.raises(dns.resolver.NoAnswer):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001:db8::1'
+
+    # also delete the v6 from the main host
+    response = client.get(reverse('nic_delete') + '?myip=::',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+
+    # expect v4 and v6 of the related host to be an NXDOMAIN now
     with pytest.raises(dns.resolver.NXDOMAIN):
         assert query_ns(TEST_HOST_RELATED, 'A') is None
     with pytest.raises(dns.resolver.NXDOMAIN):

--- a/src/nsupdate/api/_tests/test_api.py
+++ b/src/nsupdate/api/_tests/test_api.py
@@ -420,6 +420,30 @@ def test_nic_update_multiple_ips(client):
     assert content == f'good {v4_new}\nnochg {v6}'
 
 
+def test_nic_update_multiple_ips_updates_related_hosts(client):
+    v4 = '1.2.3.4'
+    v6 = '2001:db8::10'
+    response = client.get(reverse('nic_update') + f'?myip={v4},{v6}',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST, 'A') == '1.2.3.4'
+    assert query_ns(TEST_HOST, 'AAAA') == '2001:db8::10'
+    assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.1'
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001:db8::1'
+
+    v4 = '4.3.2.1'
+    v6 = '2001:8db::10'
+    response = client.get(reverse('nic_update') + f'?myip={v4},{v6}',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+
+    assert response.status_code == 200
+    assert query_ns(TEST_HOST, 'A') == '4.3.2.1'
+    assert query_ns(TEST_HOST, 'AAAA') == '2001:8db::10'
+    assert query_ns(TEST_HOST_RELATED, 'A') == '4.3.2.1'
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001:8db::1'
+
+
 def test_nic_delete_multiple_ips(client):
     # Test with multiple IPs (v4 and v6) for deletion
     v4 = '1.2.3.4'
@@ -436,3 +460,26 @@ def test_nic_delete_multiple_ips(client):
     if content == 'dnserr':
         pytest.skip("DNS server not available in test environment")
     assert content == 'deleted A,AAAA'
+
+
+def test_nic_delete_multiple_ips_deletes_related_hosts(client):
+    v4 = '4.3.2.1'
+    v6 = '2001:8db::10'
+    response = client.get(reverse('nic_update') + f'?myip={v4},{v6}',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+
+    assert response.status_code == 200
+
+    v4 = '0.0.0.0'
+    v6 = '::'
+    response = client.get(reverse('nic_delete') + f'?myip={v4},{v6}',
+                          HTTP_AUTHORIZATION=make_basic_auth_header(TEST_HOST, TEST_SECRET))
+    assert response.status_code == 200
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST, 'A') is None
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST, 'AAAA') is None
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'AAAA') is None

--- a/src/nsupdate/api/views.py
+++ b/src/nsupdate/api/views.py
@@ -4,15 +4,15 @@ Views for the (usually non-interactive, automated) web API.
 """
 
 import logging
+
+from ..utils.dns_updater import strip_ip, update_or_delete
+
 logger = logging.getLogger(__name__)
 
 import json
 import base64
 import binascii
 from importlib import import_module
-
-from netaddr import IPAddress, IPNetwork
-from netaddr.core import AddrFormatError
 
 from django.http import HttpResponse
 from django.conf import settings
@@ -21,10 +21,9 @@ from django.contrib.auth.hashers import verify_password
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
 
-from ..utils import log, ddns_client
+from ..utils import log
 from ..main.models import Host
-from ..main.dnstools import (FQDN, update, delete, check_ip, put_ip_into_session,
-                             SameIpError, DnsUpdateError, NameServerNotAvailable)
+from ..main.dnstools import (check_ip, put_ip_into_session)
 from ..main.iptools import normalize_ip
 from .utils import get_session_key_from_token
 
@@ -99,7 +98,7 @@ class AjaxGetIps(View):
             ipv6=request.session.get('ipv6', ''),
             ipv6_rdns=request.session.get('ipv6_rdns', ''),
         )
-        logger.debug("ajax_get_ips response: %r" % (response, ))
+        logger.debug("ajax_get_ips response: %r" % (response,))
         return HttpResponse(json.dumps(response), content_type='application/json')
 
 
@@ -112,7 +111,7 @@ def basic_challenge(realm, content='Authorization Required'):
     :return: HttpResponse object
     """
     response = Response(content)
-    response['WWW-Authenticate'] = 'Basic realm="%s"' % (realm, )
+    response['WWW-Authenticate'] = 'Basic realm="%s"' % (realm,)
     response.status_code = 401
     return response
 
@@ -157,7 +156,7 @@ def check_api_auth(username, password, logger=None):
         host = Host.get_by_fqdn(fqdn)
     except ValueError:
         # logging this at debug level because otherwise it fills our logs...
-        logger.debug('%s - received bad credentials (auth username == dyndns hostname not in our hosts DB)' % (fqdn, ))
+        logger.debug('%s - received bad credentials (auth username == dyndns hostname not in our hosts DB)' % (fqdn,))
         return None
     if host is not None:
         ok, must_update = verify_password(password, host.update_secret, preferred='weakargon2')
@@ -166,13 +165,13 @@ def check_api_auth(username, password, logger=None):
             host.generate_secret(password)
 
         success_msg = ('failure', 'success')[ok]
-        msg = "api authentication %s. [hostname: %s (given in basic auth)]" % (success_msg, fqdn, )
+        msg = "api authentication %s. [hostname: %s (given in basic auth)]" % (success_msg, fqdn,)
         host.register_api_auth_result(msg, fault=not ok)
         if ok:
             return host
         # in case this fills our logs and we never see valid credentials, we can just kill
         # the DB entry and this will fail earlier and get logged at debug level, see above.
-        logger.warning('%s - received bad credentials (password does not match)' % (fqdn, ))
+        logger.warning('%s - received bad credentials (password does not match)' % (fqdn,))
     return None
 
 
@@ -192,16 +191,6 @@ def check_session_auth(user, hostname):
     # we have specifically looked for a host of the logged in user,
     # we either have one now and return it, or we have None and return that.
     return host
-
-
-def _strip_ip(ipaddr):
-    """strip away spaces and trailing /xx prefix length / netmask"""
-    ipaddr = str(ipaddr).strip()
-    if '/' in ipaddr:
-        # there is a trailing /xx prefix length / netmask - get rid of it.
-        # by doing this we support myip=<ip6lanprefix> of FritzBox.
-        ipaddr = ipaddr.rsplit('/')[0]
-    return ipaddr
 
 
 def _make_response(results):
@@ -275,11 +264,11 @@ class NicUpdateView(View):
         auth = request.headers.get('authorization')
         if auth is None:
             # logging this at debug level because otherwise it fills our logs...
-            logger.debug('%s - received no auth' % (hostname, ))
+            logger.debug('%s - received no auth' % (hostname,))
             return basic_challenge("authenticate to update DNS", 'badauth')
         creds = basic_authenticate(auth)
         if not creds:
-            logger.debug('%s - received malformed auth header' % (hostname, ))
+            logger.debug('%s - received malformed auth header' % (hostname,))
             return basic_challenge("authenticate to update DNS", 'badauth')
         username, password = creds
         if '.' not in username:  # username MUST be the fqdn
@@ -322,7 +311,7 @@ class NicUpdateView(View):
             # usually it will be 1 (v4 or v6) or 2 (v4 and v6) addresses.
             ipaddrs = []
             for ip in ipaddr.split(','):
-                ip = _strip_ip(ip)
+                ip = strip_ip(ip)
                 try:
                     check_ip(ip)
                     ipaddrs.append(ip)
@@ -332,7 +321,7 @@ class NicUpdateView(View):
                 # if none of the given IPs are valid, we update to the remote_addr
                 ipaddrs = [remote_addr, ]
         secure = request.is_secure()
-        results = [_update_or_delete(host, ip, secure, logger=logger, _delete=delete) for ip in ipaddrs]
+        results = [update_or_delete(host, ip, secure, logger=logger, _delete=delete) for ip in ipaddrs]
         return _make_response(results)
 
 
@@ -379,7 +368,7 @@ class AuthorizedNicUpdateView(View):
             return Response('nohost')
         host = check_session_auth(request.user, hostname)
         if host is None:
-            logger.warning('%s - is not owned by user: %s' % (hostname, request.user.username, ))
+            logger.warning('%s - is not owned by user: %s' % (hostname, request.user.username,))
             return Response('nohost')
         logger.info("authenticated by session as user %s, creator of host %s" % (request.user.username, hostname))
         # note: we do not check the user agent here as this is interactive
@@ -394,7 +383,7 @@ class AuthorizedNicUpdateView(View):
             # usually it will be 1 (v4 or v6) or 2 (v4 and v6) addresses.
             ipaddrs = []
             for ip in ipaddr.split(','):
-                ip = _strip_ip(ip)
+                ip = strip_ip(ip)
                 try:
                     check_ip(ip)
                     ipaddrs.append(ip)
@@ -403,7 +392,7 @@ class AuthorizedNicUpdateView(View):
             if not ipaddrs:
                 ipaddrs = [remote_addr, ]
         secure = request.is_secure()
-        results = [_update_or_delete(host, ip, secure, logger=logger, _delete=delete) for ip in ipaddrs]
+        results = [update_or_delete(host, ip, secure, logger=logger, _delete=delete) for ip in ipaddrs]
         return _make_response(results)
 
 
@@ -418,180 +407,3 @@ class AuthorizedNicDeleteView(AuthorizedNicUpdateView):
         :return: HttpResponse object
         """
         return super(AuthorizedNicDeleteView, self).get(request, logger=logger, delete=delete)
-
-
-def _update_or_delete(host, ipaddr, secure=False, logger=None, _delete=False):
-    """
-    common code shared by the 2 update/delete views
-
-    :param host: host object
-    :param ipaddr: ip addr (v4 or v6)
-    :param secure: True if we use TLS/https
-    :param logger: a logger object
-    :param _delete: True for delete, False for update
-    :return: dyndns2 response string
-    """
-    mode = ('update', 'delete')[_delete]  # only use this for logging
-    # we are doing abuse / available checks rather late, so the client might
-    # get more specific responses (like 'badagent' or 'notfqdn') by earlier
-    # checks. it also avoids some code duplication if done here:
-    fqdn = host.get_fqdn()
-    if host.abuse or host.abuse_blocked:
-        msg = '%s - received %s for host with abuse / abuse_blocked flag set' % (fqdn, mode, )
-        logger.warning(msg)
-        host.register_client_result(msg, fault=False)
-        return 'abuse'
-    if not host.available:
-        # not available is like it doesn't exist
-        msg = '%s - received %s for unavailable host' % (fqdn, mode, )
-        logger.warning(msg)
-        host.register_client_result(msg, fault=False)
-        return 'nohost'
-    try:
-        ipaddr = _strip_ip(ipaddr)
-        kind = check_ip(ipaddr, ('ipv4', 'ipv6'))
-        rdtype = 'A' if kind == 'ipv4' else 'AAAA'
-        IPNetwork(ipaddr)  # raise AddrFormatError here if there is an issue with ipaddr, see #394
-    except (ValueError, UnicodeError, AddrFormatError):
-        # invalid ip address string
-        # some people manage to even give a non-ascii string instead of an ip addr
-        msg = '%s - received bad ip address: %r' % (fqdn, ipaddr)
-        logger.warning(msg)
-        host.register_client_result(msg, fault=True)
-        return 'dnserr'  # there should be a better response code for this
-
-    # If we receive an update request with an address that has only the network prefix,
-    # but the interface id is all-zero, we will NOT update DNS with a useless A or AAAA record,
-    # but rather delete any A or AAAA record we already might have, see issue #648.
-    if not _delete:
-        if kind == 'ipv4':
-            netmask = host.netmask_ipv4
-            single_ip = netmask == 32  # the usual case for home routers
-        elif kind == 'ipv6':
-            netmask = host.netmask_ipv6
-            single_ip = netmask == 128  # rather theoretical case, but who knows...
-        else:
-            raise ValueError('unknown ip address kind: %s' % kind)
-        # we do not want to update A/AAAA records with network addresses:
-        is_network = not single_ip and IPNetwork("%s/%d" % (ipaddr, netmask)).network == IPAddress(ipaddr)
-        if is_network:
-            logger.info('%s - received %s for host %s, but address has only network prefix, deleting instead' % (fqdn, mode, ipaddr, ))
-    else:
-        is_network = False
-
-    if not _delete and IPAddress(ipaddr) in settings.BAD_IPS_HOST:
-        msg = '%s - received %s to blacklisted ip address: %r' % (fqdn, mode, ipaddr)
-        logger.warning(msg)
-        host.abuse = True
-        host.abuse_blocked = True
-        host.register_client_result(msg, fault=True)
-        return 'abuse'
-    host.poke(kind, secure)
-    try:
-        if _delete or is_network:
-            delete(fqdn, rdtype)
-        else:
-            update(fqdn, ipaddr)
-    except SameIpError:
-        msg = '%s - received no-change update, ip: %s tls: %r' % (fqdn, ipaddr, secure)
-        logger.warning(msg)
-        host.register_client_result(msg, fault=True)
-        return 'nochg %s' % ipaddr
-    except (DnsUpdateError, NameServerNotAvailable) as e:
-        msg = str(e)
-        msg = '%s - received %s that resulted in a dns error [%s], ip: %s tls: %r' % (
-            fqdn, mode, msg, ipaddr, secure)
-        logger.error(msg)
-        host.register_server_result(msg, fault=True)
-        return 'dnserr'
-    else:
-        if _delete:
-            msg = '%s - received delete for record %s, tls: %r' % (fqdn, rdtype, secure)
-        else:
-            msg = '%s - received good update -> ip: %s tls: %r' % (fqdn, ipaddr, secure)
-        logger.info(msg)
-        host.register_client_result(msg, fault=False)
-        _update_related_hosts(host, kind, ipaddr, secure, logger)
-        if _delete:
-            return 'deleted %s' % rdtype
-        else:  # update
-            return 'good %s' % ipaddr
-
-
-def _update_related_hosts(host, kind, ipaddr, secure, logger):
-    """after updating the host in dns, do related other updates"""
-    # update related hosts
-    for rh in host.relatedhosts.all():
-        _update_related_host(rh, kind, ipaddr, logger, secure)
-
-    # now check if there are other services we shall relay updates to:
-    for hc in host.serviceupdaterhostconfigs.all():
-        _update_service_updater_host(hc, kind, ipaddr, logger)
-
-
-def _update_service_updater_host(host_config, kind, ipaddr, logger):
-    if (kind == 'ipv4' and host_config.give_ipv4 and host_config.service.accept_ipv4
-        or
-        kind == 'ipv6' and host_config.give_ipv6 and host_config.service.accept_ipv6):
-        kwargs = dict(
-            name=host_config.name, password=host_config.password,
-            hostname=host_config.hostname, myip=ipaddr,
-            server=host_config.service.server, path=host_config.service.path, secure=host_config.service.secure,
-        )
-        try:
-            ddns_client.dyndns2_update(**kwargs)
-        except Exception:
-            # we never want to crash here
-            kwargs.pop('password')
-            logger.exception("the dyndns2 updater raised an exception [%r]" % kwargs)
-
-
-def _update_related_host(related_host, kind, ipaddr, logger, secure):
-    host = related_host.main_host
-    fqdn = host.get_fqdn()
-    rdtype = 'A' if kind == 'ipv4' else 'AAAA'
-    if related_host.available:
-        if kind == 'ipv4':
-            ifid = related_host.interface_id_ipv4
-            netmask = host.netmask_ipv4
-            _delete = (ipaddr == '0.0.0.0')
-        else:  # kind == 'ipv6':
-            ifid = related_host.interface_id_ipv6
-            netmask = host.netmask_ipv6
-            _delete = (ipaddr == '::')
-        ifid = ifid.strip() if ifid else ifid
-        if not ifid:
-            # leave ifid empty if you don't want this rh record
-            _delete = True
-        try:
-            rh_fqdn = FQDN(related_host.name + '.' + fqdn.host, fqdn.domain)
-            if not _delete:
-                ifid = IPAddress(ifid)
-                network = IPNetwork("%s/%d" % (ipaddr, netmask))
-                rh_ipaddr = str(IPAddress(network.network) + int(ifid))
-        except (IndexError, AddrFormatError, ValueError) as e:
-            logger.warning("trouble computing address of related host %s [%s]" % (related_host, e))
-        else:
-            if not _delete:
-                logger.info("updating related host %s -> %s" % (rh_fqdn, rh_ipaddr))
-            else:
-                logger.info("deleting related host %s" % (rh_fqdn,))
-            try:
-                if not _delete:
-                    update(rh_fqdn, rh_ipaddr)
-                else:
-                    delete(rh_fqdn, rdtype)
-            except SameIpError:
-                msg = '%s - related hosts no-change update, ip: %s tls: %r' % (rh_fqdn, rh_ipaddr, secure)
-                logger.warning(msg)
-                host.register_client_result(msg, fault=True)
-            except (DnsUpdateError, NameServerNotAvailable) as e:
-                msg = str(e)
-                if not _delete:
-                    msg = '%s - related hosts update that resulted in a dns error [%s], ip: %s tls: %r' % (
-                        rh_fqdn, msg, rh_ipaddr, secure)
-                else:
-                    msg = '%s - related hosts deletion that resulted in a dns error [%s], tls: %r' % (
-                        rh_fqdn, msg, secure)
-                logger.error(msg)
-                host.register_server_result(msg, fault=True)

--- a/src/nsupdate/api/views.py
+++ b/src/nsupdate/api/views.py
@@ -515,70 +515,80 @@ def _update_or_delete(host, ipaddr, secure=False, logger=None, _delete=False):
             # XXX unclear what to do for "other services" we relay updates to
             return 'deleted %s' % rdtype
         else:  # update
-            _on_update_success(host, fqdn, kind, ipaddr, secure, logger)
+            _update_related_hosts(host, kind, ipaddr, secure, logger)
             return 'good %s' % ipaddr
 
 
-def _on_update_success(host, fqdn, kind, ipaddr, secure, logger):
+def _update_related_hosts(host, kind, ipaddr, secure, logger):
     """after updating the host in dns, do related other updates"""
     # update related hosts
-    rdtype = 'A' if kind == 'ipv4' else 'AAAA'
     for rh in host.relatedhosts.all():
-        if rh.available:
-            if kind == 'ipv4':
-                ifid = rh.interface_id_ipv4
-                netmask = host.netmask_ipv4
-            else:  # kind == 'ipv6':
-                ifid = rh.interface_id_ipv6
-                netmask = host.netmask_ipv6
-            ifid = ifid.strip() if ifid else ifid
-            _delete = not ifid  # leave ifid empty if you don't want this rh record
-            try:
-                rh_fqdn = FQDN(rh.name + '.' + fqdn.host, fqdn.domain)
-                if not _delete:
-                    ifid = IPAddress(ifid)
-                    network = IPNetwork("%s/%d" % (ipaddr, netmask))
-                    rh_ipaddr = str(IPAddress(network.network) + int(ifid))
-            except (IndexError, AddrFormatError, ValueError) as e:
-                logger.warning("trouble computing address of related host %s [%s]" % (rh, e))
-            else:
-                if not _delete:
-                    logger.info("updating related host %s -> %s" % (rh_fqdn, rh_ipaddr))
-                else:
-                    logger.info("deleting related host %s" % (rh_fqdn, ))
-                try:
-                    if not _delete:
-                        update(rh_fqdn, rh_ipaddr)
-                    else:
-                        delete(rh_fqdn, rdtype)
-                except SameIpError:
-                    msg = '%s - related hosts no-change update, ip: %s tls: %r' % (rh_fqdn, rh_ipaddr, secure)
-                    logger.warning(msg)
-                    host.register_client_result(msg, fault=True)
-                except (DnsUpdateError, NameServerNotAvailable) as e:
-                    msg = str(e)
-                    if not _delete:
-                        msg = '%s - related hosts update that resulted in a dns error [%s], ip: %s tls: %r' % (
-                            rh_fqdn, msg, rh_ipaddr, secure)
-                    else:
-                        msg = '%s - related hosts deletion that resulted in a dns error [%s], tls: %r' % (
-                            rh_fqdn, msg, secure)
-                    logger.error(msg)
-                    host.register_server_result(msg, fault=True)
+        _update_related_host(rh, kind, ipaddr, logger, secure)
 
     # now check if there are other services we shall relay updates to:
     for hc in host.serviceupdaterhostconfigs.all():
-        if (kind == 'ipv4' and hc.give_ipv4 and hc.service.accept_ipv4
-            or
-            kind == 'ipv6' and hc.give_ipv6 and hc.service.accept_ipv6):
-            kwargs = dict(
-                name=hc.name, password=hc.password,
-                hostname=hc.hostname, myip=ipaddr,
-                server=hc.service.server, path=hc.service.path, secure=hc.service.secure,
-            )
+        _update_service_updater_host(hc, kind, ipaddr, logger)
+
+
+def _update_service_updater_host(host_config, kind, ipaddr, logger):
+    if (kind == 'ipv4' and host_config.give_ipv4 and host_config.service.accept_ipv4
+        or
+        kind == 'ipv6' and host_config.give_ipv6 and host_config.service.accept_ipv6):
+        kwargs = dict(
+            name=host_config.name, password=host_config.password,
+            hostname=host_config.hostname, myip=ipaddr,
+            server=host_config.service.server, path=host_config.service.path, secure=host_config.service.secure,
+        )
+        try:
+            ddns_client.dyndns2_update(**kwargs)
+        except Exception:
+            # we never want to crash here
+            kwargs.pop('password')
+            logger.exception("the dyndns2 updater raised an exception [%r]" % kwargs)
+
+
+def _update_related_host(related_host, kind, ipaddr, logger, secure):
+    host = related_host.main_host
+    fqdn = host.get_fqdn()
+    rdtype = 'A' if kind == 'ipv4' else 'AAAA'
+    if related_host.available:
+        if kind == 'ipv4':
+            ifid = related_host.interface_id_ipv4
+            netmask = host.netmask_ipv4
+        else:  # kind == 'ipv6':
+            ifid = related_host.interface_id_ipv6
+            netmask = host.netmask_ipv6
+        ifid = ifid.strip() if ifid else ifid
+        _delete = not ifid  # leave ifid empty if you don't want this rh record
+        try:
+            rh_fqdn = FQDN(related_host.name + '.' + fqdn.host, fqdn.domain)
+            if not _delete:
+                ifid = IPAddress(ifid)
+                network = IPNetwork("%s/%d" % (ipaddr, netmask))
+                rh_ipaddr = str(IPAddress(network.network) + int(ifid))
+        except (IndexError, AddrFormatError, ValueError) as e:
+            logger.warning("trouble computing address of related host %s [%s]" % (related_host, e))
+        else:
+            if not _delete:
+                logger.info("updating related host %s -> %s" % (rh_fqdn, rh_ipaddr))
+            else:
+                logger.info("deleting related host %s" % (rh_fqdn,))
             try:
-                ddns_client.dyndns2_update(**kwargs)
-            except Exception:
-                # we never want to crash here
-                kwargs.pop('password')
-                logger.exception("the dyndns2 updater raised an exception [%r]" % kwargs)
+                if not _delete:
+                    update(rh_fqdn, rh_ipaddr)
+                else:
+                    delete(rh_fqdn, rdtype)
+            except SameIpError:
+                msg = '%s - related hosts no-change update, ip: %s tls: %r' % (rh_fqdn, rh_ipaddr, secure)
+                logger.warning(msg)
+                host.register_client_result(msg, fault=True)
+            except (DnsUpdateError, NameServerNotAvailable) as e:
+                msg = str(e)
+                if not _delete:
+                    msg = '%s - related hosts update that resulted in a dns error [%s], ip: %s tls: %r' % (
+                        rh_fqdn, msg, rh_ipaddr, secure)
+                else:
+                    msg = '%s - related hosts deletion that resulted in a dns error [%s], tls: %r' % (
+                        rh_fqdn, msg, secure)
+                logger.error(msg)
+                host.register_server_result(msg, fault=True)

--- a/src/nsupdate/api/views.py
+++ b/src/nsupdate/api/views.py
@@ -511,11 +511,10 @@ def _update_or_delete(host, ipaddr, secure=False, logger=None, _delete=False):
             msg = '%s - received good update -> ip: %s tls: %r' % (fqdn, ipaddr, secure)
         logger.info(msg)
         host.register_client_result(msg, fault=False)
+        _update_related_hosts(host, kind, ipaddr, secure, logger)
         if _delete:
-            # XXX unclear what to do for "other services" we relay updates to
             return 'deleted %s' % rdtype
         else:  # update
-            _update_related_hosts(host, kind, ipaddr, secure, logger)
             return 'good %s' % ipaddr
 
 
@@ -555,11 +554,15 @@ def _update_related_host(related_host, kind, ipaddr, logger, secure):
         if kind == 'ipv4':
             ifid = related_host.interface_id_ipv4
             netmask = host.netmask_ipv4
+            _delete = (ipaddr == '0.0.0.0')
         else:  # kind == 'ipv6':
             ifid = related_host.interface_id_ipv6
             netmask = host.netmask_ipv6
+            _delete = (ipaddr == '::')
         ifid = ifid.strip() if ifid else ifid
-        _delete = not ifid  # leave ifid empty if you don't want this rh record
+        if not ifid:
+            # leave ifid empty if you don't want this rh record
+            _delete = True
         try:
             rh_fqdn = FQDN(related_host.name + '.' + fqdn.host, fqdn.domain)
             if not _delete:

--- a/src/nsupdate/main/_tests/test_related_host_view.py
+++ b/src/nsupdate/main/_tests/test_related_host_view.py
@@ -1,0 +1,195 @@
+import base64
+from http import HTTPStatus
+from random import randint
+
+import dns
+import pytest
+from django.urls import reverse
+
+from nsupdate.conftest import TEST_HOST, RELATED_HOST_NAME, TEST_HOST_RELATED, USERNAME, PASSWORD
+from nsupdate.main.dnstools import query_ns, FQDN
+from nsupdate.main.models import Host, RelatedHost
+
+
+def make_basic_auth_header(username, password):
+    token = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {token}"
+
+
+def test_add_related_host_updates_dns(client):
+    # first set an ip for the main host
+    v4 = '1.2.3.4'
+    v6 = '2001:cafe::1'
+    client.login(username=USERNAME, password=PASSWORD)
+    response = client.get(reverse('nic_update_authorized') + f'?hostname={TEST_HOST}&myip={v4},{v6}')
+    assert response.status_code == HTTPStatus.OK
+
+    # then add a related host
+    related_host_name = 'related%da' % randint(1, 1000000)
+    related_host_fqdn = FQDN(related_host_name + '.' + TEST_HOST.host, TEST_HOST.domain)
+    main_host = Host.objects.filter(name=TEST_HOST.host)[0]
+    response = client.post(reverse('add_related_host', args=[main_host.id]), data={
+        'name': related_host_name,
+        'available': 1,
+        'interface_id_ipv4': '0.0.0.1',
+        'interface_id_ipv6': '::1',
+    })
+    assert response.status_code == HTTPStatus.FOUND
+    assert response.headers['location'] == f'/host/{main_host.id}/related/'
+
+    # expect the related host to have an appropriate ip
+    assert query_ns(related_host_fqdn, 'A') == '1.2.3.1'  # 1.2.3.4/29 + 0.0.0.1
+    assert query_ns(related_host_fqdn, 'AAAA') == '2001:cafe::1'  # 2001:cafe::1/64 + ::1
+
+
+def test_delete_related_host_updates_dns(client):
+    # main host and related host are already set up by fixtures
+    # now set an ip for the main host
+    v4 = '1.2.3.4'
+    v6 = '2001:cafe::1'
+    client.login(username=USERNAME, password=PASSWORD)
+    response = client.get(reverse('nic_update_authorized') + f'?hostname={TEST_HOST}&myip={v4},{v6}')
+    assert response.status_code == HTTPStatus.OK
+
+    # expect the related host to have an appropriate ip
+    assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.1'  # 1.2.3.4/29 + 0.0.0.1
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001:cafe::1'  # 2001:cafe::1/64 + ::1
+
+    # delete the related host
+    main_host = Host.objects.filter(name=TEST_HOST.host)[0]
+    related_host = RelatedHost.objects.filter(main_host=main_host, name=RELATED_HOST_NAME)[0]
+    response = client.post(reverse('delete_related_host', args=[main_host.id, related_host.id]))
+    assert response.status_code == HTTPStatus.FOUND
+    assert response.headers['location'] == f'/host/{main_host.id}/related/'
+
+    # expect the related host to not exist anymore
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'AAAA') is None
+
+
+def test_update_related_host_interface_id_when_main_host_has_ip_updates_dns(client):
+    # main host and related host are already set up by fixtures
+    # now set an ip for the main host
+    v4 = '1.2.3.4'
+    v6 = '2001:cafe::1'
+    client.login(username=USERNAME, password=PASSWORD)
+    response = client.get(reverse('nic_update_authorized') + f'?hostname={TEST_HOST}&myip={v4},{v6}')
+    assert response.status_code == HTTPStatus.OK
+
+    # expect the related host to have an appropriate ip
+    assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.1'  # 1.2.3.4/29 + 0.0.0.1
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001:cafe::1'  # 2001:cafe::1/64 + ::1
+
+    # now update the related host's interface ids
+    main_host = Host.objects.filter(name=TEST_HOST.host)[0]
+    related_host = RelatedHost.objects.filter(main_host=main_host, name=RELATED_HOST_NAME)[0]
+    response = client.post(reverse('related_host_view', args=[main_host.id, related_host.id]), data={
+        'name': RELATED_HOST_NAME,
+        'available': 1,
+        'interface_id_ipv4': '0.0.0.2',
+        'interface_id_ipv6': '::2',
+    })
+    assert response.status_code == HTTPStatus.FOUND
+
+    # expect the related host to have an appropriate ip
+    assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.2'  # 1.2.3.4/29 + 0.0.0.2
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001:cafe::2'  # 2001:cafe::1/64 + ::2
+
+
+def test_update_related_host_interface_id_when_main_host_has_no_ip_succeeds(client):
+    # main host and related host are already set up by fixtures
+
+    # delete ip from main-host
+    client.login(username=USERNAME, password=PASSWORD)
+    response = client.get(reverse('nic_delete_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '0.0.0.0'))
+    assert response.status_code == 200
+    response = client.get(reverse('nic_delete_authorized') + '?hostname=%s&myip=%s' % (TEST_HOST, '::'))
+    assert response.status_code == 200
+
+    # expect the related host to not exist
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'AAAA') is None
+
+    # update the related host's interface id
+    main_host = Host.objects.filter(name=TEST_HOST.host)[0]
+    related_host = RelatedHost.objects.filter(main_host=main_host, name=RELATED_HOST_NAME)[0]
+    response = client.post(reverse('related_host_view', args=[main_host.id, related_host.id]), data={
+        'name': RELATED_HOST_NAME,
+        'available': 1,
+        'interface_id_ipv4': '0.0.0.2',
+        'interface_id_ipv6': '::2',
+    })
+
+    # expect to succeed anyway
+    assert response.status_code == HTTPStatus.FOUND
+
+    # expect the related host to still not exist
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'AAAA') is None
+
+
+def test_delete_related_host_interface_id_updates_dns(client):
+    # main host and related host are already set up by fixtures
+    # now set an ip for the main host
+    v4 = '1.2.3.4'
+    v6 = '2001:cafe::1'
+    client.login(username=USERNAME, password=PASSWORD)
+    response = client.get(reverse('nic_update_authorized') + f'?hostname={TEST_HOST}&myip={v4},{v6}')
+    assert response.status_code == HTTPStatus.OK
+
+    # expect the related host to have an appropriate ip
+    assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.1'  # 1.2.3.4/29 + 0.0.0.1
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001:cafe::1'  # 2001:cafe::1/64 + ::1
+
+    # remove related host v4 interface id
+    main_host = Host.objects.filter(name=TEST_HOST.host)[0]
+    related_host = RelatedHost.objects.filter(main_host=main_host, name=RELATED_HOST_NAME)[0]
+    response = client.post(reverse('related_host_view', args=[main_host.id, related_host.id]), data={
+        'name': RELATED_HOST_NAME,
+        'available': 1,
+        'interface_id_ipv4': '',
+        'interface_id_ipv6': '::1',
+    })
+    assert response.status_code == HTTPStatus.FOUND
+
+    # expect the related host to have no v4 address anymore
+    with pytest.raises(dns.resolver.NoAnswer):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None
+    assert query_ns(TEST_HOST_RELATED, 'AAAA') == '2001:cafe::1'
+
+    # remove the v6 interface id, set ipv4
+    response = client.post(reverse('related_host_view', args=[main_host.id, related_host.id]), data={
+        'name': RELATED_HOST_NAME,
+        'available': 1,
+        'interface_id_ipv4': '0.0.0.1',
+        'interface_id_ipv6': '',
+
+    })
+    assert response.status_code == HTTPStatus.FOUND
+
+    # expect the related host to have no v6 address anymore
+    assert query_ns(TEST_HOST_RELATED, 'A') == '1.2.3.1'
+    with pytest.raises(dns.resolver.NoAnswer):
+        assert query_ns(TEST_HOST_RELATED, 'AAAA') is None
+
+    # remove both interface ids
+    response = client.post(reverse('related_host_view', args=[main_host.id, related_host.id]), data={
+        'name': RELATED_HOST_NAME,
+        'available': 1,
+        'interface_id_ipv4': '',
+        'interface_id_ipv6': '',
+
+    })
+    assert response.status_code == HTTPStatus.FOUND
+
+    # expect the domain to be gone
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'A') is None
+    with pytest.raises(dns.resolver.NXDOMAIN):
+        assert query_ns(TEST_HOST_RELATED, 'AAAA') is None

--- a/src/nsupdate/main/_tests/test_related_host_view.py
+++ b/src/nsupdate/main/_tests/test_related_host_view.py
@@ -193,3 +193,47 @@ def test_delete_related_host_interface_id_updates_dns(client):
         assert query_ns(TEST_HOST_RELATED, 'A') is None
     with pytest.raises(dns.resolver.NXDOMAIN):
         assert query_ns(TEST_HOST_RELATED, 'AAAA') is None
+
+
+invalid_interface_ids_ipv4 = [
+    ('1'),
+    ('1.1'),
+    ('1.1.1'),
+    # 1.1.1.1 is ok
+    ('1.1.1.1.1'),
+    ('foo'),
+    ('1.1.1.1/32'),
+    ('::1'),
+]
+
+invalid_interface_ids_ipv6 = [
+    ('1'),
+    ('1.1.1.1'),
+    ('1::1::1'),
+    ('foo'),
+    ('::1/64'),
+]
+
+
+@pytest.mark.parametrize("interface_id_ipv4", invalid_interface_ids_ipv4)
+def test_update_related_host_invalid_interface_id_v4_fails(client, interface_id_ipv4):
+    main_host = Host.objects.filter(name=TEST_HOST.host)[0]
+    related_host = RelatedHost.objects.filter(main_host=main_host, name=RELATED_HOST_NAME)[0]
+    client.login(username=USERNAME, password=PASSWORD)
+    response = client.post(reverse('related_host_view', args=[main_host.id, related_host.id]), data={
+        'interface_id_ipv4': interface_id_ipv4,
+    })
+    assert response.status_code == HTTPStatus.OK
+    assert 'is not a valid interface-id for IPv4' in response.text
+
+
+@pytest.mark.parametrize("interface_id_ipv6", invalid_interface_ids_ipv6)
+def test_update_related_host_invalid_interface_id_v6_fails(client, interface_id_ipv6):
+    main_host = Host.objects.filter(name=TEST_HOST.host)[0]
+    related_host = RelatedHost.objects.filter(main_host=main_host, name=RELATED_HOST_NAME)[0]
+    client.login(username=USERNAME, password=PASSWORD)
+    response = client.post(reverse('related_host_view', args=[main_host.id, related_host.id]), data={
+        'interface_id_ipv6': interface_id_ipv6,
+    })
+    assert response.status_code == HTTPStatus.OK
+    assert 'is not a valid interface-id for IPv6' in response.text

--- a/src/nsupdate/main/models.py
+++ b/src/nsupdate/main/models.py
@@ -1,25 +1,25 @@
 """
 Models for hosts, domains, and service updaters.
 """
-
+import base64
+import logging
 import re
 import secrets
 import time
-import base64
 
-import dns.resolver
 import dns.message
-
-from django.db import models
+import dns.resolver
+from django.conf import settings
+from django.contrib.auth.hashers import make_password
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
-from django.conf import settings
+from django.db import models
 from django.db.models.signals import pre_delete, post_save
-from django.contrib.auth.hashers import make_password
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 
 from . import dnstools
+from ..utils.dns_updater import update_related_host
 
 RESULT_MSG_LEN = 255
 
@@ -445,7 +445,22 @@ class RelatedHost(models.Model):
         return self.get_ip('ipv6')
 
 
+def post_save_related_host(sender, **kwargs):
+    logger = logging.getLogger("post_save_related_host")
+    related_host = kwargs['instance']
+    logger.debug("post_save_related_host sender={} instance={} main_host={}", sender, related_host, related_host.main_host)
+
+    main_host_ipv4 = related_host.main_host.get_ipv4()
+    main_host_ipv6 = related_host.main_host.get_ipv6()
+    if main_host_ipv4:
+        update_related_host(related_host, "ipv4", main_host_ipv4, logger, "internal")
+
+    if main_host_ipv6:
+        update_related_host(related_host, "ipv6", main_host_ipv6, logger, "internal")
+
+
 pre_delete.connect(pre_delete_host, sender=RelatedHost)
+post_save.connect(post_save_related_host, sender=RelatedHost)
 
 
 class ServiceUpdater(models.Model):

--- a/src/nsupdate/main/models.py
+++ b/src/nsupdate/main/models.py
@@ -17,6 +17,7 @@ from django.db import models
 from django.db.models.signals import pre_delete, post_save
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
+from netaddr import IPAddress, AddrFormatError
 
 from . import dnstools
 from ..utils.dns_updater import update_related_host
@@ -373,6 +374,30 @@ def post_save_host(sender, **kwargs):
 post_save.connect(post_save_host, sender=Host)
 
 
+def validate_interface_id_v4(value):
+    validate_interface_id(value, 4)
+
+
+def validate_interface_id_v6(value):
+    validate_interface_id(value, 6)
+
+
+def validate_interface_id(value, version):
+    try:
+        ip_address = IPAddress(value)
+        if ip_address.version != version:
+            raise ValidationError(
+                _("%(value)s is not a valid interface-id for IPv%(v)s"),
+                params={"value": value, "v": version},
+            )
+
+    except (IndexError, AddrFormatError, ValueError):
+        raise ValidationError(
+            _("%(value)s is not a valid interface-id for IPv%(v)s"),
+            params={"value": value, "v": version},
+        )
+
+
 class RelatedHost(models.Model):
     # host addr = network_of_main_host + interface_id
     name = models.CharField(
@@ -394,12 +419,14 @@ class RelatedHost(models.Model):
         _("interface ID IPv4"),
         default='', blank=True, null=True,
         max_length=16,
-        help_text=_("The IPv4 interface ID of this host. Use IPv4 notation. Empty = do not set record."))
+        help_text=_("The IPv4 interface ID of this host. Use IPv4 notation. Empty = do not set record."),
+        validators=[validate_interface_id_v4])
     interface_id_ipv6 = models.CharField(
         _("interface ID IPv6"),
         default='', blank=True, null=True,
         max_length=40,
-        help_text=_("The IPv6 interface ID of this host. Use IPv6 notation. Empty = do not set record."))
+        help_text=_("The IPv6 interface ID of this host. Use IPv6 notation. Empty = do not set record."),
+        validators=[validate_interface_id_v6])
     available = models.BooleanField(
         _("available"),
         default=True,

--- a/src/nsupdate/utils/dns_updater.py
+++ b/src/nsupdate/utils/dns_updater.py
@@ -1,0 +1,192 @@
+from django.conf import settings
+from netaddr import IPNetwork, AddrFormatError, IPAddress
+
+from nsupdate.main.dnstools import check_ip, delete, update, SameIpError, DnsUpdateError, NameServerNotAvailable, FQDN
+from nsupdate.utils import ddns_client
+
+
+def strip_ip(ipaddr):
+    """strip away spaces and trailing /xx prefix length / netmask"""
+    ipaddr = str(ipaddr).strip()
+    if '/' in ipaddr:
+        # there is a trailing /xx prefix length / netmask - get rid of it.
+        # by doing this we support myip=<ip6lanprefix> of FritzBox.
+        ipaddr = ipaddr.rsplit('/')[0]
+    return ipaddr
+
+
+def update_or_delete(host, ipaddr, secure=False, logger=None, _delete=False):
+    """
+    common code shared by the 2 update/delete views
+
+    :param host: host object
+    :param ipaddr: ip addr (v4 or v6)
+    :param secure: True if we use TLS/https
+    :param logger: a logger object
+    :param _delete: True for delete, False for update
+    :return: dyndns2 response string
+    """
+    mode = ('update', 'delete')[_delete]  # only use this for logging
+    # we are doing abuse / available checks rather late, so the client might
+    # get more specific responses (like 'badagent' or 'notfqdn') by earlier
+    # checks. it also avoids some code duplication if done here:
+    fqdn = host.get_fqdn()
+    if host.abuse or host.abuse_blocked:
+        msg = '%s - received %s for host with abuse / abuse_blocked flag set' % (fqdn, mode,)
+        logger.warning(msg)
+        host.register_client_result(msg, fault=False)
+        return 'abuse'
+    if not host.available:
+        # not available is like it doesn't exist
+        msg = '%s - received %s for unavailable host' % (fqdn, mode,)
+        logger.warning(msg)
+        host.register_client_result(msg, fault=False)
+        return 'nohost'
+    try:
+        ipaddr = strip_ip(ipaddr)
+        kind = check_ip(ipaddr, ('ipv4', 'ipv6'))
+        rdtype = 'A' if kind == 'ipv4' else 'AAAA'
+        IPNetwork(ipaddr)  # raise AddrFormatError here if there is an issue with ipaddr, see #394
+    except (ValueError, UnicodeError, AddrFormatError):
+        # invalid ip address string
+        # some people manage to even give a non-ascii string instead of an ip addr
+        msg = '%s - received bad ip address: %r' % (fqdn, ipaddr)
+        logger.warning(msg)
+        host.register_client_result(msg, fault=True)
+        return 'dnserr'  # there should be a better response code for this
+
+    # If we receive an update request with an address that has only the network prefix,
+    # but the interface id is all-zero, we will NOT update DNS with a useless A or AAAA record,
+    # but rather delete any A or AAAA record we already might have, see issue #648.
+    if not _delete:
+        if kind == 'ipv4':
+            netmask = host.netmask_ipv4
+            single_ip = netmask == 32  # the usual case for home routers
+        elif kind == 'ipv6':
+            netmask = host.netmask_ipv6
+            single_ip = netmask == 128  # rather theoretical case, but who knows...
+        else:
+            raise ValueError('unknown ip address kind: %s' % kind)
+        # we do not want to update A/AAAA records with network addresses:
+        is_network = not single_ip and IPNetwork("%s/%d" % (ipaddr, netmask)).network == IPAddress(ipaddr)
+        if is_network:
+            logger.info('%s - received %s for host %s, but address has only network prefix, deleting instead' % (fqdn, mode, ipaddr,))
+    else:
+        is_network = False
+
+    if not _delete and IPAddress(ipaddr) in settings.BAD_IPS_HOST:
+        msg = '%s - received %s to blacklisted ip address: %r' % (fqdn, mode, ipaddr)
+        logger.warning(msg)
+        host.abuse = True
+        host.abuse_blocked = True
+        host.register_client_result(msg, fault=True)
+        return 'abuse'
+    host.poke(kind, secure)
+    try:
+        if _delete or is_network:
+            delete(fqdn, rdtype)
+        else:
+            update(fqdn, ipaddr)
+    except SameIpError:
+        msg = '%s - received no-change update, ip: %s tls: %r' % (fqdn, ipaddr, secure)
+        logger.warning(msg)
+        host.register_client_result(msg, fault=True)
+        return 'nochg %s' % ipaddr
+    except (DnsUpdateError, NameServerNotAvailable) as e:
+        msg = str(e)
+        msg = '%s - received %s that resulted in a dns error [%s], ip: %s tls: %r' % (
+            fqdn, mode, msg, ipaddr, secure)
+        logger.error(msg)
+        host.register_server_result(msg, fault=True)
+        return 'dnserr'
+    else:
+        if _delete:
+            msg = '%s - received delete for record %s, tls: %r' % (fqdn, rdtype, secure)
+        else:
+            msg = '%s - received good update -> ip: %s tls: %r' % (fqdn, ipaddr, secure)
+        logger.info(msg)
+        host.register_client_result(msg, fault=False)
+        _update_related_hosts(host, kind, ipaddr, secure, logger)
+        if _delete:
+            return 'deleted %s' % rdtype
+        else:  # update
+            return 'good %s' % ipaddr
+
+
+def _update_related_hosts(host, kind, ipaddr, secure, logger):
+    """after updating the host in dns, do related other updates"""
+    # update related hosts
+    for rh in host.relatedhosts.all():
+        update_related_host(rh, kind, ipaddr, logger, secure)
+
+    # now check if there are other services we shall relay updates to:
+    for hc in host.serviceupdaterhostconfigs.all():
+        _update_service_updater_host(hc, kind, ipaddr, logger)
+
+
+def _update_service_updater_host(host_config, kind, ipaddr, logger):
+    if (kind == 'ipv4' and host_config.give_ipv4 and host_config.service.accept_ipv4
+        or
+        kind == 'ipv6' and host_config.give_ipv6 and host_config.service.accept_ipv6):
+        kwargs = dict(
+            name=host_config.name, password=host_config.password,
+            hostname=host_config.hostname, myip=ipaddr,
+            server=host_config.service.server, path=host_config.service.path, secure=host_config.service.secure,
+        )
+        try:
+            ddns_client.dyndns2_update(**kwargs)
+        except Exception:
+            # we never want to crash here
+            kwargs.pop('password')
+            logger.exception("the dyndns2 updater raised an exception [%r]" % kwargs)
+
+
+def update_related_host(related_host, kind, ipaddr, logger, secure):
+    host = related_host.main_host
+    fqdn = host.get_fqdn()
+    rdtype = 'A' if kind == 'ipv4' else 'AAAA'
+    if related_host.available:
+        if kind == 'ipv4':
+            ifid = related_host.interface_id_ipv4
+            netmask = host.netmask_ipv4
+            _delete = (ipaddr == '0.0.0.0')
+        else:  # kind == 'ipv6':
+            ifid = related_host.interface_id_ipv6
+            netmask = host.netmask_ipv6
+            _delete = (ipaddr == '::')
+        ifid = ifid.strip() if ifid else ifid
+        if not ifid:
+            # leave ifid empty if you don't want this rh record
+            _delete = True
+        try:
+            rh_fqdn = FQDN(related_host.name + '.' + fqdn.host, fqdn.domain)
+            if not _delete:
+                ifid = IPAddress(ifid)
+                network = IPNetwork("%s/%d" % (ipaddr, netmask))
+                rh_ipaddr = str(IPAddress(network.network) + int(ifid))
+        except (IndexError, AddrFormatError, ValueError) as e:
+            logger.warning("trouble computing address of related host %s [%s]" % (related_host, e))
+        else:
+            if not _delete:
+                logger.info("updating related host %s -> %s" % (rh_fqdn, rh_ipaddr))
+            else:
+                logger.info("deleting related host %s" % (rh_fqdn,))
+            try:
+                if not _delete:
+                    update(rh_fqdn, rh_ipaddr)
+                else:
+                    delete(rh_fqdn, rdtype)
+            except SameIpError:
+                msg = '%s - related hosts no-change update, ip: %s tls: %r' % (rh_fqdn, rh_ipaddr, secure)
+                logger.warning(msg)
+                host.register_client_result(msg, fault=True)
+            except (DnsUpdateError, NameServerNotAvailable) as e:
+                msg = str(e)
+                if not _delete:
+                    msg = '%s - related hosts update that resulted in a dns error [%s], ip: %s tls: %r' % (
+                        rh_fqdn, msg, rh_ipaddr, secure)
+                else:
+                    msg = '%s - related hosts deletion that resulted in a dns error [%s], tls: %r' % (
+                        rh_fqdn, msg, secure)
+                logger.error(msg)
+                host.register_server_result(msg, fault=True)


### PR DESCRIPTION
Based on #701, so this is should be reviewed and merged after #701

This PR improves the user experience when using related hosts further, so that the result fits more closely to what one might naively expect. Especially it fixes these flows:
 - adding a related host directly creates its dns records
 - updating a related host's interface-ids directly updates its dns records
 - deleting a related host's interface-ids directly deletes its associated dns records
 - deleting a host's ip also delete's all of its related host's ip addresses of the same kind
 - interface-ids are now validated for a parsable format in the related host form

i believe this fixes #672 and #302

This PR is ready but I kept it in draft mode, because this follows #701 and reviewing them serially would make review easier.