### PR TITLE
Hardcoded test parameters can now be overridden in a local test_override.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.pot
 *.pyc
 local_settings.py
-test_override.py
+local_test_settings.py
 .coverage
 .cache/
 .tox/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pot
 *.pyc
 local_settings.py
+test_override.py
 .coverage
 .cache/
 .tox/

--- a/src/nsupdate/conftest.py
+++ b/src/nsupdate/conftest.py
@@ -2,6 +2,7 @@
 configuration for the (py.test based) tests
 """
 
+import os
 import pytest
 
 from random import randint
@@ -35,8 +36,20 @@ _PASSWORD = 'yUTvxjRwNu'  # no problem, is only used for this unit test
 SERVER = 'ipv4.' + BASEDOMAIN
 SECURE = False  # Do not use TLS for these tests.
 
-from django.utils.translation import activate
 
+# Values above can locally be overridden by a test_override.py right beside this conftest.py .
+# This file is gitignored, similarly to local_settings.py . For example, by running test with a different BASE_DOMAIN,
+# enter a line "BASE_DOMAIN=your.alternate.domain" into test_override.py .
+
+test_override_path = os.path.join(os.path.dirname(__file__), "test_override.py")
+
+if os.path.exists(test_override_path):
+    from .test_override import *
+else:
+    pass
+
+
+from django.utils.translation import activate
 from nsupdate.main.dnstools import update_ns, FQDN
 
 

--- a/src/nsupdate/conftest.py
+++ b/src/nsupdate/conftest.py
@@ -2,13 +2,9 @@
 configuration for the (py.test based) tests
 """
 
-import os
 import pytest
-
 from random import randint
-
 from nsupdate.main.dnstools import FQDN
-
 from django.conf import settings
 
 # this is to create a Domain entries in the database, so they can be used for unit tests:
@@ -37,15 +33,13 @@ SERVER = 'ipv4.' + BASEDOMAIN
 SECURE = False  # Do not use TLS for these tests.
 
 
-# Values above can locally be overridden by a test_override.py right beside this conftest.py .
+# Values above can locally be overridden by a local_test_settings.py in the PYTHONPATH .
 # This file is gitignored, similarly to local_settings.py . For example, by running test with a different BASE_DOMAIN,
-# enter a line "BASE_DOMAIN=your.alternate.domain" into test_override.py .
+# enter a line "BASE_DOMAIN=your.alternate.domain" into local_test_settings.py . This file can be anywhere in the PYTHONPATH.
 
-test_override_path = os.path.join(os.path.dirname(__file__), "test_override.py")
-
-if os.path.exists(test_override_path):
-    from .test_override import *
-else:
+try:
+    from local_test_settings import *
+except ImportError:
     pass
 
 


### PR DESCRIPTION
That is highly useful if the test environment can not (or does not want to) follow exactly the predefined one. Idea is that we can override the values with a local, gitignored file, called "test_override.py", right beside conftest.py . Essentially, it is a local_settings.py for tests.

I think, this change should be also documented what I could happily do. First question is, what do the Claude and Thomas say for this change.

Reason is very simple: many people dislikes docker, beside that debugging tools inside containers is an extra bonus pain. However, in a more traditional test setup, we have more often a need to have some localized settings on various reasons.